### PR TITLE
TimestampSerializer should not depend on Locale

### DIFF
--- a/ecs-logging-core/src/main/java/co/elastic/logging/TimestampSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/TimestampSerializer.java
@@ -26,6 +26,7 @@ package co.elastic.logging;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -109,7 +110,7 @@ class TimestampSerializer {
         private final long endOfCachedDate;
 
         private CachedDate(long epochTimestamp) {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
             dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
             cachedDateIso = dateFormat.format(new Date(epochTimestamp));
             startOfCachedDate = atStartOfDay(epochTimestamp);

--- a/ecs-logging-core/src/test/java/co/elastic/logging/TimestampSerializerTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/TimestampSerializerTest.java
@@ -33,6 +33,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,10 +42,23 @@ class TimestampSerializerTest {
     private TimestampSerializer dateSerializer;
     private DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneId.of("UTC"));
 
-
     @BeforeEach
     void setUp() {
         dateSerializer = new TimestampSerializer();
+    }
+
+    @Test
+    public void testSerializeWithCustomLocale() throws InterruptedException {
+        Locale.setDefault(new Locale.Builder()
+                .setLanguage("uz")
+                .setRegion("UZ")
+                .setScript("Cyrl")
+                .build());
+
+        dateSerializer = new TimestampSerializer();
+
+        long timestamp = Instant.now().toEpochMilli();
+        assertDateFormattingIsCorrect(Instant.ofEpochMilli(timestamp));
     }
 
     @Test


### PR DESCRIPTION
Users are expected to run any custom locale which impacts how
TimestampSerializer caches formatted date. To avoid that Locale.ROOT is
used to ignore user's set locale