### PR TITLE
Step one of remove java-ecs-logging-mbp job

### DIFF
--- a/.ci/jobs/java-ecs-logging-mbp.yml
+++ b/.ci/jobs/java-ecs-logging-mbp.yml
@@ -1,0 +1,5 @@
+---
+- job:
+    name: apm-agent-java/java-ecs-logging-mbp
+    display-name: java-ecs-logging
+    description: Centralized logging for Java applications with the Elastic stack


### PR DESCRIPTION
There was a request made in a private repo to remove the old `java-ecs-logging-mbp` job. The way to do that is a little odd, in that we have to first create a job definition that matches the old job and then remove it, which should trigger the automation which rebuilds jobs. This PR is the first of two, the second of which will follow up by removing this file.