### PR TITLE
Parameterized logging jul

### DIFF
--- a/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
@@ -69,9 +69,9 @@ public abstract class AbstractEcsLoggingTest {
         }
 
         if (parameterizedLogSupport == ParameterizedLogSupport.NUMBER_AND_BRACKETS) {
-            debug("{0} is not {1}", new Object[]{1, 2});
+            debug("{0} is not {1}", 1, 2);
         } else if (parameterizedLogSupport == ParameterizedLogSupport.BRACKETS_ONLY) {
-            debug("{} is not {}", new Object[]{1, 2});
+            debug("{} is not {}", 1, 2);
         }
 
         assertThat(getLastLogLine().get("message").textValue()).isEqualTo("1 is not 2");
@@ -148,7 +148,7 @@ public abstract class AbstractEcsLoggingTest {
 
     public abstract void debug(String message);
 
-    public abstract void debug(String message, Object[] logParams);
+    public abstract void debug(String message, Object... logParams);
 
     public abstract void error(String message, Throwable t);
 

--- a/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
@@ -60,6 +60,24 @@ public abstract class AbstractEcsLoggingTest {
     }
 
     @Test
+    void testSimpleParameterizedLog() throws Exception {
+        ParameterizedLogSupport parameterizedLogSupport = getParameterizedLogSettings();
+
+        // don't test parameterized logging if the log framework implementation does not support it.
+        if (parameterizedLogSupport == ParameterizedLogSupport.NOT_SUPPORTED) {
+            return;
+        }
+
+        if (parameterizedLogSupport == ParameterizedLogSupport.NUMBER_AND_BRACKETS) {
+            debug("{0} is not {1}", new Object[]{1, 2});
+        } else if (parameterizedLogSupport == ParameterizedLogSupport.BRACKETS_ONLY) {
+            debug("{} is not {}", new Object[]{1, 2});
+        }
+
+        assertThat(getLastLogLine().get("message").textValue()).isEqualTo("1 is not 2");
+    }
+
+    @Test
     void testThreadContext() throws Exception {
         if (putMdc("foo", "bar")) {
             debug("test");
@@ -124,7 +142,13 @@ public abstract class AbstractEcsLoggingTest {
         return false;
     }
 
+    public ParameterizedLogSupport getParameterizedLogSettings() {
+        return ParameterizedLogSupport.BRACKETS_ONLY;
+    }
+
     public abstract void debug(String message);
+
+    public abstract void debug(String message, Object[] logParams);
 
     public abstract void error(String message, Throwable t);
 

--- a/ecs-logging-core/src/test/java/co/elastic/logging/ParameterizedLogSupport.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/ParameterizedLogSupport.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging;
+
+/**
+ * Logging frameworks differ in their implementation of log formatting.
+ * For example JUL and Jboss only support formatting when the message is structured as follows: "Log: {0}"
+ * whereas more recent log frameworks only support it with the following message: "Log: {}"
+ * Log4j does not support parameterized logging.
+ */
+public enum ParameterizedLogSupport {
+    BRACKETS_ONLY, // {}, {}
+    NUMBER_AND_BRACKETS, // {0}, {1}
+    NOT_SUPPORTED
+}

--- a/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/EcsFormatterTest.java
+++ b/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/EcsFormatterTest.java
@@ -90,7 +90,7 @@ class EcsFormatterTest {
             }
         });
 
-        assertThat(formatter.format(record)).isEqualTo("{" +
+        assertThat(formatter.format(record).replace("\\r\\n", "\\n")).isEqualTo("{" +
                 "\"@timestamp\":\"1970-01-01T00:00:00.005Z\", " +
                 "\"log.level\": \"INFO\", " +
                 "\"message\":\"Example Message\", " +

--- a/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/JBossLogManagerTest.java
+++ b/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/JBossLogManagerTest.java
@@ -71,7 +71,7 @@ class JBossLogManagerTest extends AbstractEcsLoggingTest {
     }
 
     @Override
-    public void debug(String message, Object[] logParams) {
+    public void debug(String message, Object... logParams) {
         logger.log(Level.DEBUG, message, logParams);
     }
 

--- a/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/JBossLogManagerTest.java
+++ b/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/JBossLogManagerTest.java
@@ -25,6 +25,7 @@
 package co.elastic.logging.jboss.logmanager;
 
 import co.elastic.logging.AbstractEcsLoggingTest;
+import co.elastic.logging.ParameterizedLogSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.jboss.logmanager.Level;
 import org.jboss.logmanager.Logger;
@@ -62,6 +63,16 @@ class JBossLogManagerTest extends AbstractEcsLoggingTest {
     @Override
     public void debug(String message) {
         logger.log(Level.DEBUG, message);
+    }
+
+    @Override
+    public ParameterizedLogSupport getParameterizedLogSettings() {
+        return ParameterizedLogSupport.NUMBER_AND_BRACKETS;
+    }
+
+    @Override
+    public void debug(String message, Object[] logParams) {
+        logger.log(Level.DEBUG, message, logParams);
     }
 
     @Override

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
@@ -56,7 +56,7 @@ public class EcsFormatter extends Formatter {
         final StringBuilder builder = new StringBuilder();
         EcsJsonSerializer.serializeObjectStart(builder, record.getMillis());
         EcsJsonSerializer.serializeLogLevel(builder, record.getLevel().getName());
-        EcsJsonSerializer.serializeFormattedMessage(builder, record.getMessage());
+        EcsJsonSerializer.serializeFormattedMessage(builder, super.formatMessage(record));
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadId(builder, record.getThreadID());

--- a/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTestTest.java
+++ b/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTestTest.java
@@ -92,7 +92,7 @@ public class JulLoggingTestTest extends AbstractEcsLoggingTest {
     }
 
     @Override
-    public void debug(String message, Object[] logParams) {
+    public void debug(String message, Object... logParams) {
         logger.log(Level.FINE, message, logParams);
     }
 

--- a/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTestTest.java
+++ b/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTestTest.java
@@ -41,6 +41,7 @@ import java.util.logging.StreamHandler;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import co.elastic.logging.ParameterizedLogSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -83,6 +84,16 @@ public class JulLoggingTestTest extends AbstractEcsLoggingTest {
     @Override
     public void debug(String message) {
         logger.log(Level.FINE, message);
+    }
+
+    @Override
+    public ParameterizedLogSupport getParameterizedLogSettings() {
+        return ParameterizedLogSupport.NUMBER_AND_BRACKETS;
+    }
+
+    @Override
+    public void debug(String message, Object[] logParams) {
+        logger.log(Level.FINE, message, logParams);
     }
 
     @Override

--- a/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
+++ b/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
@@ -86,7 +86,7 @@ class Log4jEcsLayoutTest extends AbstractEcsLoggingTest {
     }
 
     @Override
-    public void debug(String message, Object[] logParams) {
+    public void debug(String message, Object... logParams) {
         throw new UnsupportedOperationException();
     }
 

--- a/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
+++ b/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
@@ -25,11 +25,9 @@
 package co.elastic.logging.log4j;
 
 import co.elastic.logging.AbstractEcsLoggingTest;
+import co.elastic.logging.ParameterizedLogSupport;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.apache.log4j.MDC;
-import org.apache.log4j.NDC;
+import org.apache.log4j.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,6 +78,16 @@ class Log4jEcsLayoutTest extends AbstractEcsLoggingTest {
     @Override
     public void debug(String message) {
         logger.debug(message);
+    }
+
+    @Override
+    public ParameterizedLogSupport getParameterizedLogSettings() {
+        return ParameterizedLogSupport.NOT_SUPPORTED;
+    }
+
+    @Override
+    public void debug(String message, Object[] logParams) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/AbstractLog4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/AbstractLog4j2EcsLayoutTest.java
@@ -195,7 +195,7 @@ abstract class AbstractLog4j2EcsLayoutTest extends AbstractEcsLoggingTest {
     }
 
     @Override
-    public void debug(String message, Object[] logParams) {
+    public void debug(String message, Object... logParams) {
         root.debug(message, logParams);
     }
 

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/AbstractLog4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/AbstractLog4j2EcsLayoutTest.java
@@ -195,6 +195,11 @@ abstract class AbstractLog4j2EcsLayoutTest extends AbstractEcsLoggingTest {
     }
 
     @Override
+    public void debug(String message, Object[] logParams) {
+        root.debug(message, logParams);
+    }
+
+    @Override
     public void error(String message, Throwable t) {
         root.error(message, t);
     }

--- a/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/AbstractEcsEncoderTest.java
+++ b/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/AbstractEcsEncoderTest.java
@@ -48,6 +48,11 @@ abstract class AbstractEcsEncoderTest extends AbstractEcsLoggingTest {
         logger.debug(message);
     }
 
+    @Override
+    public void debug(String message, Object[] logParams) {
+        logger.debug(message, logParams);
+    }
+
     @Test
     void testAdditionalFields() throws Exception {
         debug("test");

--- a/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/AbstractEcsEncoderTest.java
+++ b/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/AbstractEcsEncoderTest.java
@@ -49,7 +49,7 @@ abstract class AbstractEcsEncoderTest extends AbstractEcsLoggingTest {
     }
 
     @Override
-    public void debug(String message, Object[] logParams) {
+    public void debug(String message, Object... logParams) {
         logger.debug(message, logParams);
     }
 


### PR DESCRIPTION
The java util logging formatter logged the following method call:
logger.log(Level.INFO, "test {0}", "test1"); as "test {0}" in the message field of the json body whereas "test test1" is the intended behaviour.

By using the super.formatMessage method from the JUL Formatter the parameters do get placed into the curly brackets. 

I have also added a .replace("\\r\\n", "\\n") in a unit test because the unit test does not work on windows because the line endings are different.