### PR TITLE
Add SLF4J MDC support for JUL

### DIFF
--- a/jul-ecs-formatter/pom.xml
+++ b/jul-ecs-formatter/pom.xml
@@ -27,6 +27,17 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.30</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
-
 </project>

--- a/jul-ecs-formatter/pom.xml
+++ b/jul-ecs-formatter/pom.xml
@@ -38,6 +38,7 @@
             <artifactId>slf4j-jdk14</artifactId>
             <version>1.7.30</version>
             <optional>true</optional>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/jul-ecs-formatter/pom.xml
+++ b/jul-ecs-formatter/pom.xml
@@ -37,7 +37,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>1.7.30</version>
-            <optional>true</optional>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
@@ -33,6 +33,7 @@ import co.elastic.logging.EcsJsonSerializer;
 public class EcsFormatter extends Formatter {
 
     private static final String UNKNOWN_FILE = "<Unknown>";
+    private static final MdcSupplier mdcSupplier = MdcSupplier.Resolver.INSTANCE.resolve();
     
     private boolean stackTraceAsArray;
     private String serviceName;
@@ -57,6 +58,7 @@ public class EcsFormatter extends Formatter {
         EcsJsonSerializer.serializeObjectStart(builder, record.getMillis());
         EcsJsonSerializer.serializeLogLevel(builder, record.getLevel().getName());
         EcsJsonSerializer.serializeFormattedMessage(builder, super.formatMessage(record));
+        EcsJsonSerializer.serializeMDC(builder, mdcSupplier.getMDC());
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadId(builder, record.getThreadID());

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/MdcSupplier.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/MdcSupplier.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging.jul;
+
+import org.slf4j.MDC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public interface MdcSupplier {
+    Map<String, String> getMDC();
+
+    enum Resolver {
+        INSTANCE;
+
+        MdcSupplier resolve() {
+            try {
+                Class.forName("org.slf4j.MDC");
+
+                // The SLF4J API dependency does not contain an MDC binder by itself, the MDC binders come from an SLF4j
+                // implementation. When no MDC bindings are available calls to MDC.put will be ignored by slf4j.
+                // That is why we want to ensure that the StaticMDCBinder exists
+                Class.forName("org.slf4j.impl.StaticMDCBinder");
+                return Available.INSTANCE;
+            } catch (Exception e) {
+                return Unavailable.INSTANCE;
+            } catch (LinkageError e ) {
+                return Unavailable.INSTANCE;
+            }
+        }
+    }
+
+    enum Available implements MdcSupplier {
+        INSTANCE;
+
+        Available() {
+        }
+
+        @Override
+        public Map<String, String> getMDC() {
+            Map<String, String> copyOfContextMap = MDC.getCopyOfContextMap();
+            if (copyOfContextMap != null ) {
+                return copyOfContextMap;
+            }
+            return new HashMap<String, String>();
+        }
+    }
+
+    enum Unavailable implements MdcSupplier {
+        INSTANCE;
+
+        Unavailable() {
+        }
+
+        @Override
+        public Map<String, String> getMDC() {
+            return new HashMap<String, String>();
+        }
+    }
+}

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/MdcSupplier.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/MdcSupplier.java
@@ -43,7 +43,7 @@ public interface MdcSupplier {
                 // implementation. When no MDC bindings are available calls to MDC.put will be ignored by slf4j.
                 // That is why we want to ensure that the StaticMDCBinder exists
                 Class.forName("org.slf4j.impl.StaticMDCBinder");
-                return Available.INSTANCE;
+                return (MdcSupplier) Class.forName("co.elastic.logging.jul.MdcSupplier$Available").getEnumConstants()[0];
             } catch (Exception e) {
                 return Unavailable.INSTANCE;
             } catch (LinkageError e ) {

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/MdcSupplier.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/MdcSupplier.java
@@ -26,7 +26,7 @@ package co.elastic.logging.jul;
 
 import org.slf4j.MDC;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 public interface MdcSupplier {
@@ -61,7 +61,7 @@ public interface MdcSupplier {
             if (copyOfContextMap != null ) {
                 return copyOfContextMap;
             }
-            return new HashMap<String, String>();
+            return Collections.emptyMap();
         }
     }
 
@@ -73,7 +73,7 @@ public interface MdcSupplier {
 
         @Override
         public Map<String, String> getMDC() {
-            return new HashMap<String, String>();
+            return Collections.emptyMap();
         }
     }
 }

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/MdcSupplier.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/MdcSupplier.java
@@ -55,9 +55,6 @@ public interface MdcSupplier {
     enum Available implements MdcSupplier {
         INSTANCE;
 
-        Available() {
-        }
-
         @Override
         public Map<String, String> getMDC() {
             Map<String, String> copyOfContextMap = MDC.getCopyOfContextMap();

--- a/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTest.java
+++ b/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTest.java
@@ -48,8 +48,9 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import co.elastic.logging.AbstractEcsLoggingTest;
+import org.slf4j.MDC;
 
-public class JulLoggingTestTest extends AbstractEcsLoggingTest {
+public class JulLoggingTest extends AbstractEcsLoggingTest {
 
     private static final class InMemoryStreamHandler extends StreamHandler {
         private InMemoryStreamHandler(OutputStream out, Formatter formatter) {
@@ -84,6 +85,12 @@ public class JulLoggingTestTest extends AbstractEcsLoggingTest {
     @Override
     public void debug(String message) {
         logger.log(Level.FINE, message);
+    }
+
+    @Override
+    public boolean putMdc(String key, String value) {
+        MDC.put(key, value);
+        return true;
     }
 
     @Override
@@ -131,7 +138,7 @@ public class JulLoggingTestTest extends AbstractEcsLoggingTest {
         String stackTrace = StreamSupport.stream(getLastLogLine().get("error.stack_trace").spliterator(), false)
                 .map(JsonNode::textValue)
                 .collect(Collectors.joining("\n", "", "\n"));
-        assertThat(stackTrace).contains("at co.elastic.logging.jul.JulLoggingTestTest.testLogException");
+        assertThat(stackTrace).contains("at co.elastic.logging.jul.JulLoggingTest.testLogException");
     }
     
     @Test


### PR DESCRIPTION
Pull request for issue: #78.

This pull requests adds mdc support for JUL which is useful for legacy applications that want to use APM.

Before merging please review the MdcSupplier interface. I implemented it similar to the `ObjectMessageJacksonSerializer`  interface but I noticed that the `ObjectMessageJacksonSerializer` does not have unit tests for when there is no Jackson Objectmapper on the classpath. Currently this is similar to my implementation of `MdcSupplier`where the `MdcSupplier.Unavailable`, which is used if slf4j is not on the classpath, is not tested with unit tests. I am not really sure how to proceed with this issue. 