### PR TITLE
Return ContentType of "application/json" instead of "text/plain"

### DIFF
--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -355,6 +355,11 @@ public class EcsLayout extends AbstractStringLayout {
             return includeOrigin;
         }
 
+        @Override
+        public String getContentType() {
+            return "application/json";
+        }
+
         /**
          * Additional fields to set on each log event.
          *

--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -123,6 +123,11 @@ public class EcsLayout extends AbstractStringLayout {
         helper.encode(text, destination);
     }
 
+    @Override
+    public String getContentType() {
+        return "application/json";
+    }
+
     private StringBuilder toText(LogEvent event, StringBuilder builder, boolean gcFree) {
         EcsJsonSerializer.serializeObjectStart(builder, event.getTimeMillis());
         EcsJsonSerializer.serializeLogLevel(builder, event.getLevel().toString());
@@ -353,11 +358,6 @@ public class EcsLayout extends AbstractStringLayout {
 
         public boolean isIncludeOrigin() {
             return includeOrigin;
-        }
-
-        @Override
-        public String getContentType() {
-            return "application/json";
         }
 
         /**


### PR DESCRIPTION
Override the ECSLayout parent class's ([org.apache.logging.log4j.core.layout.AbstractStringLayout line 222](https://github.com/apache/logging-log4j2/blob/606cf7fc95d281cbd491f558bc981c1db020d7f7/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/AbstractStringLayout.java)) "getContentType()" function which always returns `text/plain`, so that it returns the ECS-appropriate `application/json` instead.

This change adds support for use of the ECS Layout in conjunction with the [log4j2 HTTP  #Appender](https://github.com/apache/logging-log4j2/blob/e741549928b2acbcb2d11ad285aa84ee88728e49/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/HttpAppender.java)

Usage of the layout's "getContentType()" function can be seen on  [line 89 of the HttpURLConnectionManager class, in the "send()" function](https://github.com/apache/logging-log4j2/blob/e741549928b2acbcb2d11ad285aa84ee88728e49/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/HttpURLConnectionManager.java) ,which decides the `Content-Type` header the logs will be sent with. 

This PR is to help close #89 