### PR TITLE
Fix for issue #92 : when trying to serialize null, serialize it as th…

### DIFF
--- a/ecs-logging-core/src/main/java/co/elastic/logging/JsonUtils.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/JsonUtils.java
@@ -60,6 +60,7 @@ public final class JsonUtils {
     public static void quoteAsString(CharSequence content, StringBuilder sb) {
         if (content == null) {
             sb.append("null");
+            return;
         }
         final int[] escCodes = sOutputEscapes128;
         final int escLen = escCodes.length;

--- a/ecs-logging-core/src/main/java/co/elastic/logging/JsonUtils.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/JsonUtils.java
@@ -58,6 +58,9 @@ public final class JsonUtils {
     }
 
     public static void quoteAsString(CharSequence content, StringBuilder sb) {
+        if (content == null) {
+            sb.append("null");
+        }
         final int[] escCodes = sOutputEscapes128;
         final int escLen = escCodes.length;
         for (int i = 0, len = content.length(); i < len; ++i) {

--- a/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
@@ -24,6 +24,7 @@
  */
 package co.elastic.logging;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,13 @@ class EcsJsonSerializerTest {
         StringWriter stringWriter = new StringWriter();
         exception.printStackTrace(new PrintWriter(stringWriter));
         assertThat(jsonNode.get("error.stack_trace").textValue()).isEqualTo(stringWriter.toString());
+    }
+
+    @Test
+    void serializeNullDoesNotThrowAnException() throws JsonProcessingException {
+        StringBuilder stringBuilder = new StringBuilder();
+        EcsJsonSerializer.serializeFormattedMessage(stringBuilder, null);
+        assertThat(stringBuilder.toString()).isEqualTo("\"message\":\"null\", ");
     }
 
     @Test


### PR DESCRIPTION
…e string "null"

When trying to serialize a CharSequence that is null, serialize it as the string null.
To avoid null checks propagation.