### PR TITLE
docs: Fix broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 .idea
 **.iml
+
+# Local doc build files
+html_docs

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -108,7 +108,7 @@ like Logstash, Kafka or Redis.
 *Index Lifecycle management*::
 +
 --
-Leverage Filebeat's default {filebeat-ref}/master/ilm.html[index lifemanagement settings].
+Leverage Filebeat's default {filebeat-ref}/ilm.html[index lifecycle management settings].
 This is much more efficient than using daily indices.
 --
 

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -29,10 +29,7 @@ include::./tab-widgets/ecs-encoder-widget.asciidoc[]
 [[setup-step-2]]
 === Step 2: Enable APM log correlation (optional)
 If you are using the Elastic APM Java agent,
-set {apm-java-ref}/current/config-logging.html#config-enable-log-correlation[`enable_log_correlation`] to `true`.
-
-
-
+set {apm-java-ref}/config-logging.html#config-enable-log-correlation[`enable_log_correlation`] to `true`.
 
 [float]
 [[setup-step-3]]

--- a/docs/structured-logging-log4j2.asciidoc
+++ b/docs/structured-logging-log4j2.asciidoc
@@ -1,3 +1,4 @@
+[structured-logging-log4j2]
 == Structured logging with log4j2
 
 By leveraging log4j2's `MapMessage` or even by implementing your own `MultiformatMessage` with JSON support,
@@ -56,7 +57,7 @@ In recent Elasticsearch versions, the following JSON structures would result in 
 }
 ----
 
-The property `foo` would be mapped to the {ref}/current/object.html[Object datatype].
+The property `foo` would be mapped to the {ref}/object.html[Object datatype].
 
 This means that you can't index a document where `foo` would be a different datatype, as in shown in the following example:
 


### PR DESCRIPTION
This PR fixes broken documentation links discovered when adding the docs to the build.

```
09:52:52 INFO:build_docs:  Branch master
09:52:52 INFO:build_docs:Bad cross-document links:
09:52:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/current/_structured_logging_with_log4j2.html:
09:52:52 INFO:build_docs:   - en/elasticsearch/reference/7.10/current/object.html
09:52:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/current/intro.html:
09:52:52 INFO:build_docs:   - en/beats/filebeat/7.10/master/ilm.html
09:52:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/current/setup.html:
09:52:52 INFO:build_docs:   - en/apm/agent/java/current/current/config-logging.html
09:52:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/master/_structured_logging_with_log4j2.html:
09:52:52 INFO:build_docs:   - en/elasticsearch/reference/7.10/current/object.html
09:52:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/master/intro.html:
09:52:52 INFO:build_docs:   - en/beats/filebeat/7.10/master/ilm.html
09:52:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/master/setup.html:
09:52:52 INFO:build_docs:   - en/apm/agent/java/current/current/config-logging.html
```

For https://github.com/elastic/docs/pull/2010.