### PR TITLE
docs: update GitHub links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please note that we reserve GitHub tickets for confirmed bugs and enhancement re
 
 ## Documentation
 
-Docs are located on [elastic.co](https://www.elastic.co/guide/en/ecs-logging/java).
+Docs are located on [elastic.co](https://www.elastic.co/guide/en/ecs-logging/java/current/index.html).
 
 ## License
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -3,7 +3,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]
 NOTE: For the best reading experience,
-please view this documentation at https://www.elastic.co/guide/en/ecs-logging/java[elastic.co]
+please view this documentation at https://www.elastic.co/guide/en/ecs-logging/java/current/index.html[elastic.co]
 endif::[]
 
 = ECS Logging Java Reference


### PR DESCRIPTION
Adds the correct link to the newly published docs: https://www.elastic.co/guide/en/ecs-logging/java/current/index.html