### PR TITLE
Logback Encoder: Configuration for using ThrowableHandlingConverters

### DIFF
--- a/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -34,7 +34,7 @@ public class EcsJsonSerializer {
 
     private static final TimestampSerializer TIMESTAMP_SERIALIZER = new TimestampSerializer();
     private static final ThreadLocal<StringBuilder> messageStringBuilder = new ThreadLocal<StringBuilder>();
-    private static final  String NEW_LINE = System.getProperty("line.separator");
+    private static final String NEW_LINE = System.getProperty("line.separator");
     private static final Pattern NEW_LINE_PATTERN = Pattern.compile("\\n");
 
     public static CharSequence toNullSafeString(final CharSequence s) {
@@ -79,6 +79,7 @@ public class EcsJsonSerializer {
         builder.append(threadId);
         builder.append(",");
     }
+
     public static void serializeFormattedMessage(StringBuilder builder, String message) {
         builder.append("\"message\":\"");
         JsonUtils.quoteAsString(message, builder);
@@ -214,26 +215,21 @@ public class EcsJsonSerializer {
         builder.append("\"error.type\":\"");
         JsonUtils.quoteAsString(exceptionClassName, builder);
         builder.append("\",");
-        builder.append("\"error.message\":\"");
-        JsonUtils.quoteAsString(exceptionMessage, builder);
-        builder.append("\",");
+
+        if (exceptionMessage != null) {
+            builder.append("\"error.message\":\"");
+            JsonUtils.quoteAsString(exceptionMessage, builder);
+            builder.append("\",");
+        }
         if (stackTraceAsArray) {
-            builder.append("\"error.stack_trace\":[").append(NEW_LINE);
-            for (String line : NEW_LINE_PATTERN.split(stackTrace)) {
-                appendQuoted(builder, line);
-            }
+            builder.append("\"error.stack_trace\":[");
+            formatStackTraceAsArray(builder, stackTrace);
             builder.append("]");
         } else {
             builder.append("\"error.stack_trace\":\"");
             JsonUtils.quoteAsString(stackTrace, builder);
             builder.append("\"");
         }
-    }
-
-    private static void appendQuoted(StringBuilder builder, CharSequence content) {
-        builder.append('"');
-        JsonUtils.quoteAsString(content, builder);
-        builder.append('"');
     }
 
     private static CharSequence formatThrowable(final Throwable throwable) {
@@ -260,6 +256,18 @@ public class EcsJsonSerializer {
         throwable.printStackTrace(pw);
         removeIfEndsWith(jsonBuilder, NEW_LINE);
         removeIfEndsWith(jsonBuilder, ",");
+    }
+
+    private static void formatStackTraceAsArray(StringBuilder builder, String stackTrace) {
+        builder.append(NEW_LINE);
+        for (String line : NEW_LINE_PATTERN.split(stackTrace)) {
+            builder.append("\t\"");
+            JsonUtils.quoteAsString(line, builder);
+            builder.append("\",");
+            builder.append(NEW_LINE);
+        }
+        removeIfEndsWith(builder, NEW_LINE);
+        removeIfEndsWith(builder, ",");
     }
 
     public static void removeIfEndsWith(StringBuilder sb, String ending) {

--- a/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.within;
 public abstract class AbstractEcsLoggingTest {
 
     protected ObjectMapper objectMapper = new ObjectMapper();
-    private JsonNode spec;
+    protected JsonNode spec;
 
     @BeforeEach
     final void setUpSpec() throws Exception {

--- a/logback-ecs-encoder/src/main/java/co/elastic/logging/logback/EcsEncoder.java
+++ b/logback-ecs-encoder/src/main/java/co/elastic/logging/logback/EcsEncoder.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,13 +24,14 @@
  */
 package co.elastic.logging.logback;
 
+import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
 import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.core.encoder.EncoderBase;
-import co.elastic.logging.EcsJsonSerializer;
 import co.elastic.logging.AdditionalField;
+import co.elastic.logging.EcsJsonSerializer;
 import org.slf4j.Marker;
 
 import java.io.IOException;
@@ -48,7 +49,8 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
     private String serviceNodeName;
     private String eventDataset;
     private boolean includeMarkers = false;
-    private ThrowableProxyConverter throwableProxyConverter;
+    private ThrowableHandlingConverter throwableConverter = null;
+    private final ThrowableProxyConverter throwableProxyConverter = new ThrowableProxyConverter();
     private boolean includeOrigin;
     private final List<AdditionalField> additionalFields = new ArrayList<AdditionalField>();
     private OutputStream os;
@@ -61,10 +63,13 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
     @Override
     public void start() {
         super.start();
-        throwableProxyConverter = new ThrowableProxyConverter();
         throwableProxyConverter.start();
+        if (throwableConverter != null) {
+            throwableConverter.start();
+        }
         eventDataset = EcsJsonSerializer.computeEventDataset(eventDataset, serviceName);
     }
+
     /**
      * This method has been removed in logback 1.2.
      * To make this lib backwards compatible with logback 1.1 we have implement this method.
@@ -117,10 +122,14 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
         // Allow subclasses to add custom fields. Calling this before the throwable serialization so we don't need to check for presence/absence of an ending comma.
         addCustomFields(event, builder);
         IThrowableProxy throwableProxy = event.getThrowableProxy();
-        if (throwableProxy instanceof ThrowableProxy) {
-            EcsJsonSerializer.serializeException(builder, ((ThrowableProxy) throwableProxy).getThrowable(), stackTraceAsArray);
-        } else if (throwableProxy != null) {
-            EcsJsonSerializer.serializeException(builder, throwableProxy.getClassName(), throwableProxy.getMessage(), throwableProxyConverter.convert(event), stackTraceAsArray);
+        if (throwableProxy != null) {
+            if (throwableConverter != null) {
+                EcsJsonSerializer.serializeException(builder, throwableProxy.getClassName(), throwableProxy.getMessage(), throwableConverter.convert(event), stackTraceAsArray);
+            } else if (throwableProxy instanceof ThrowableProxy) {
+                EcsJsonSerializer.serializeException(builder, ((ThrowableProxy) throwableProxy).getThrowable(), stackTraceAsArray);
+            } else {
+                EcsJsonSerializer.serializeException(builder, throwableProxy.getClassName(), throwableProxy.getMessage(), throwableProxyConverter.convert(event), stackTraceAsArray);
+            }
         }
         EcsJsonSerializer.serializeObjectEnd(builder);
         // all these allocations kinda hurt
@@ -186,4 +195,7 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
         this.eventDataset = eventDataset;
     }
 
+    public void setThrowableConverter(ThrowableHandlingConverter throwableConverter) {
+        this.throwableConverter = throwableConverter;
+    }
 }

--- a/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderWithCustomThrowableConverterIntegrationTest.java
+++ b/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderWithCustomThrowableConverterIntegrationTest.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2021 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging.logback;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EcsEncoderWithCustomThrowableConverterIntegrationTest extends AbstractEcsEncoderTest {
+    private OutputStreamAppender appender;
+
+    @BeforeEach
+    void setUp() throws JoranException {
+        LoggerContext context = new LoggerContext();
+        ContextInitializer contextInitializer = new ContextInitializer(context);
+        contextInitializer.configureByResource(this.getClass().getResource("/logback-config-with-nop-throwable-converter.xml"));
+        logger = context.getLogger("root");
+        appender = (OutputStreamAppender) logger.getAppender("out");
+    }
+
+    @Override
+    public JsonNode getLastLogLine() throws IOException {
+        return objectMapper.readTree(appender.getBytes());
+    }
+
+    @Test
+    void testLogException() throws Exception {
+        error("test", new RuntimeException("test"));
+        JsonNode log = getAndValidateLastLogLine();
+        assertThat(log.get("log.level").textValue()).isIn("ERROR", "SEVERE");
+        assertThat(log.get("error.message").textValue()).isEqualTo("test");
+        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
+        assertThat(log.get("error.stack_trace").textValue()).contains("");
+    }
+}

--- a/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderWithStacktraceAsArrayTest.java
+++ b/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderWithStacktraceAsArrayTest.java
@@ -1,0 +1,88 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2021 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging.logback;
+
+import ch.qos.logback.classic.LoggerContext;
+import co.elastic.logging.AdditionalField;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EcsEncoderWithStacktraceAsArrayTest extends AbstractEcsEncoderTest {
+
+    private OutputStreamAppender appender;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        LoggerContext context = new LoggerContext();
+        logger = context.getLogger(getClass());
+        appender = new OutputStreamAppender();
+        appender.setContext(context);
+        logger.addAppender(appender);
+        EcsEncoder ecsEncoder = new EcsEncoder();
+        ecsEncoder.setServiceName("test");
+        ecsEncoder.setIncludeMarkers(true);
+        ecsEncoder.setIncludeOrigin(true);
+        ecsEncoder.addAdditionalField(new AdditionalField("key1", "value1"));
+        ecsEncoder.addAdditionalField(new AdditionalField("key2", "value2"));
+        ecsEncoder.setEventDataset("testdataset");
+        ecsEncoder.setServiceNodeName("test-node");
+        ecsEncoder.setStackTraceAsArray(true);
+        ecsEncoder.start();
+        appender.setEncoder(ecsEncoder);
+        appender.start();
+    }
+
+    @Override
+    public JsonNode getLastLogLine() throws IOException {
+        return objectMapper.readTree(appender.getBytes());
+    }
+
+    @Test
+    void testLogException() throws Exception {
+        error("test", new RuntimeException("test"));
+        JsonNode log = getLastLogLine();
+        assertThat(log.get("log.level").textValue()).isIn("ERROR", "SEVERE");
+        assertThat(log.get("error.message").textValue()).isEqualTo("test");
+        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
+        assertThat(log.get("error.stack_trace").isArray()).isTrue();
+        assertThat(log.get("error.stack_trace").get(0).textValue()).isEqualTo("java.lang.RuntimeException: test");
+        assertThat(log.get("error.stack_trace").get(1).textValue()).contains("at co.elastic.logging.logback.EcsEncoderWithStacktraceAsArrayTest");
+    }
+
+    @Test
+    void testLogExceptionNullMessage() throws Exception {
+        error("test", new RuntimeException());
+        JsonNode log = getLastLogLine();
+        assertThat(log.get("error.message")).isNull();
+        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
+        assertThat(log.get("error.stack_trace").get(0).textValue()).isEqualTo("java.lang.RuntimeException");
+        assertThat(log.get("error.stack_trace").get(1).textValue()).contains("at co.elastic.logging.logback.EcsEncoderWithStacktraceAsArrayTest");
+    }
+}

--- a/logback-ecs-encoder/src/test/resources/logback-config-with-nop-throwable-converter.xml
+++ b/logback-ecs-encoder/src/test/resources/logback-config-with-nop-throwable-converter.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="out" class="co.elastic.logging.logback.OutputStreamAppender">
+        <encoder class="co.elastic.logging.logback.EcsEncoder">
+            <throwableConverter class="ch.qos.logback.classic.pattern.NopThrowableInformationConverter"/>
+            <serviceName>test</serviceName>
+            <serviceNodeName>test-node</serviceNodeName>
+            <includeMarkers>true</includeMarkers>
+            <includeOrigin>true</includeOrigin>
+            <topLevelLabel>top_level</topLevelLabel>
+            <eventDataset>testdataset</eventDataset>
+            <additionalField>
+                <key>key1</key>
+                <value>value1</value>
+            </additionalField>
+            <additionalField>
+                <key>key2</key>
+                <value>value2</value>
+            </additionalField>
+        </encoder>
+    </appender>
+    <root level="DEBUG">
+        <appender-ref ref="out"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Relates to #103 

This PR includes:
 - ability to configure a single `ThrowableHandlingConverter` in the ecs logback encoder (example below)
 - a fix for serialising stack traces as an array inside https://github.com/elastic/ecs-logging-java/blob/09c07cf451bebb86f82e3f21abc0579455d81ee8/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java#L201

Example usage:

```
<configuration>
    <appender name="out" class="co.elastic.logging.logback.OutputStreamAppender">
        <encoder class="co.elastic.logging.logback.EcsEncoder">
            <throwableConverter class="ch.qos.logback.classic.pattern.NopThrowableInformationConverter"/>
            <serviceName>test</serviceName>
        </encoder>
    </appender>
    <root level="DEBUG">
        <appender-ref ref="out"/>
    </root>
</configuration>