### PR TITLE
Adding service version

### DIFF
--- a/docs/tab-widgets/ecs-encoder.asciidoc
+++ b/docs/tab-widgets/ecs-encoder.asciidoc
@@ -50,7 +50,12 @@ All you have to do is to use the `co.elastic.logging.logback.EcsEncoder` instead
 |`serviceName`
 |String
 |
-|Sets the `service.name` field so you can filter your logs by a particular service
+|Sets the `service.name` field so you can filter your logs by a particular service name
+
+|`serviceVersion`
+|String
+|
+|Sets the `service.version` field so you can filter your logs by a particular service version
 
 |`eventDataset`
 |String
@@ -125,7 +130,12 @@ For example:
 |`serviceName`
 |String
 |
-|Sets the `service.name` field so you can filter your logs by a particular service
+|Sets the `service.name` field so you can filter your logs by a particular service name
+
+|`serviceVersion`
+|String
+|
+|Sets the `service.version` field so you can filter your logs by a particular service version
 
 |`eventDataset`
 |String
@@ -205,7 +215,12 @@ For example:
 |`serviceName`
 |String
 |
-|Sets the `service.name` field so you can filter your logs by a particular service
+|Sets the `service.name` field so you can filter your logs by a particular service name
+
+|`serviceVersion`
+|String
+|
+|Sets the `service.version` field so you can filter your logs by a particular service version
 
 |`eventDataset`
 |String
@@ -259,7 +274,12 @@ co.elastic.logging.jul.EcsFormatter.serviceName=my-app
 |`serviceName`
 |String
 |
-|Sets the `service.name` field so you can filter your logs by a particular service
+|Sets the `service.name` field so you can filter your logs by a particular service name
+
+|`serviceVersion`
+|String
+|
+|Sets the `service.version` field so you can filter your logs by a particular service version
 
 |`eventDataset`
 |String
@@ -313,7 +333,12 @@ $WILDFLY_HOME/bin/jboss-cli.sh -c '/subsystem=logging/custom-formatter=ECS:add(m
 |`serviceName`
 |String
 |
-|Sets the `service.name` field so you can filter your logs by a particular service
+|Sets the `service.name` field so you can filter your logs by a particular service name
+
+|`serviceVersion`
+|String
+|
+|Sets the `service.version` field so you can filter your logs by a particular service version
 
 |`eventDataset`
 |String

--- a/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -88,6 +88,12 @@ public class EcsJsonSerializer {
     public static void serializeServiceName(StringBuilder builder, String serviceName) {
         if (serviceName != null) {
             builder.append("\"service.name\":\"").append(serviceName).append("\",");
+        }
+    }
+
+    public static void serializeServiceVersion(StringBuilder builder, String serviceVersion) {
+        if (serviceVersion != null) {
+            builder.append("\"service.version\":\"").append(serviceVersion).append("\",");
         }
     }
 

--- a/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
@@ -57,6 +57,7 @@ public abstract class AbstractEcsLoggingTest {
         debug("test");
         assertThat(getAndValidateLastLogLine().get("process.thread.name").textValue()).isEqualTo(Thread.currentThread().getName());
         assertThat(getAndValidateLastLogLine().get("service.name").textValue()).isEqualTo("test");
+        assertThat(getAndValidateLastLogLine().get("service.version").textValue()).isEqualTo("1.0.0");
         assertThat(Instant.parse(getAndValidateLastLogLine().get("@timestamp").textValue())).isCloseTo(Instant.now(), within(1, ChronoUnit.MINUTES));
         assertThat(getAndValidateLastLogLine().get("log.level").textValue()).isIn("DEBUG", "FINE");
         assertThat(getAndValidateLastLogLine().get("log.logger")).isNotNull();

--- a/ecs-logging-core/src/test/resources/spec/spec.json
+++ b/ecs-logging-core/src/test/resources/spec/spec.json
@@ -76,6 +76,15 @@
                 "When an APM agent is active, they should auto-configure it if not already set."
             ]
         },
+        "service.version": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, they should auto-configure it if not already set."
+            ]
+        },
         "event.dataset": {
             "type": "string",
             "required": false,

--- a/jboss-logmanager-ecs-formatter/src/main/java/co/elastic/logging/jboss/logmanager/EcsFormatter.java
+++ b/jboss-logmanager-ecs-formatter/src/main/java/co/elastic/logging/jboss/logmanager/EcsFormatter.java
@@ -37,6 +37,7 @@ import java.util.List;
 public class EcsFormatter extends ExtFormatter {
 
     private String serviceName;
+    private String serviceVersion;
     private String eventDataset;
     private List<AdditionalField> additionalFields = Collections.emptyList();
     private boolean includeOrigin;
@@ -44,6 +45,7 @@ public class EcsFormatter extends ExtFormatter {
 
     public EcsFormatter() {
         serviceName = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.serviceName", null);
+        serviceVersion = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.serviceVersion", null);
         eventDataset = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.eventDataset", null);
         eventDataset = EcsJsonSerializer.computeEventDataset(eventDataset, serviceName);
         includeOrigin = Boolean.getBoolean(getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.includeOrigin", "false"));
@@ -58,6 +60,7 @@ public class EcsFormatter extends ExtFormatter {
         EcsJsonSerializer.serializeFormattedMessage(builder, record.getFormattedMessage());
         EcsJsonSerializer.serializeEcsVersion(builder);
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
+        EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadName(builder, record.getThreadName());
         EcsJsonSerializer.serializeLoggerName(builder, record.getLoggerName());
@@ -89,6 +92,10 @@ public class EcsFormatter extends ExtFormatter {
     public void setServiceName(final String serviceName) {
         this.serviceName = serviceName;
         eventDataset = EcsJsonSerializer.computeEventDataset(eventDataset, serviceName);
+    }
+
+    public void setServiceVersion(String serviceVersion) {
+        this.serviceVersion = serviceVersion;
     }
 
     public void setStackTraceAsArray(final boolean stackTraceAsArray) {

--- a/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/JBossLogManagerTest.java
+++ b/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/JBossLogManagerTest.java
@@ -89,6 +89,7 @@ class JBossLogManagerTest extends AbstractEcsLoggingTest {
     void setUp() {
         formatter.setIncludeOrigin(true);
         formatter.setServiceName("test");
+        formatter.setServiceVersion("1.0.0");
         formatter.setEventDataset("testdataset.log");
         formatter.setAdditionalFields("key1=value1,key2=value2");
 

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,9 +37,10 @@ public class EcsFormatter extends Formatter {
 
     private static final String UNKNOWN_FILE = "<Unknown>";
     private static final MdcSupplier mdcSupplier = MdcSupplier.Resolver.INSTANCE.resolve();
-    
+
     private boolean stackTraceAsArray;
     private String serviceName;
+    private String serviceVersion;
     private boolean includeOrigin;
     private String eventDataset;
     private List<AdditionalField> additionalFields = Collections.emptyList();
@@ -49,6 +50,7 @@ public class EcsFormatter extends Formatter {
      */
     public EcsFormatter() {
         serviceName = getProperty("co.elastic.logging.jul.EcsFormatter.serviceName", null);
+        serviceVersion = getProperty("co.elastic.logging.jul.EcsFormatter.serviceVersion", null);
         includeOrigin = Boolean.getBoolean(getProperty("co.elastic.logging.jul.EcsFormatter.includeOrigin", "false"));
         stackTraceAsArray = Boolean
                 .getBoolean(getProperty("co.elastic.logging.jul.EcsFormatter.stackTraceAsArray", "false"));
@@ -67,6 +69,7 @@ public class EcsFormatter extends Formatter {
         EcsJsonSerializer.serializeAdditionalFields(builder, additionalFields);
         EcsJsonSerializer.serializeMDC(builder, mdcSupplier.getMDC());
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
+        EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         if (Thread.currentThread().getId() == record.getThreadID()) {
             EcsJsonSerializer.serializeThreadName(builder, Thread.currentThread().getName());
@@ -93,10 +96,14 @@ public class EcsFormatter extends Formatter {
         this.serviceName = serviceName;
     }
 
+    public void setServiceVersion(String serviceVersion) {
+        this.serviceVersion = serviceVersion;
+    }
+
     protected void setStackTraceAsArray(final boolean stackTraceAsArray) {
         this.stackTraceAsArray = stackTraceAsArray;
     }
-    
+
     public void setEventDataset(String eventDataset) {
         this.eventDataset = eventDataset;
     }

--- a/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTest.java
+++ b/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -68,9 +68,9 @@ public class JulLoggingTest extends AbstractEcsLoggingTest {
     }
 
     private final EcsFormatter formatter = new EcsFormatter();
-    
+
     private final Logger logger = Logger.getLogger("");
-    
+
     private final ByteArrayOutputStream out = new ByteArrayOutputStream();
 
     private LogRecord record;
@@ -100,7 +100,7 @@ public class JulLoggingTest extends AbstractEcsLoggingTest {
     public void error(String message, Throwable t) {
         logger.log(Level.SEVERE, message, t);
     }
-    
+
     @Override
     public JsonNode getLastLogLine() throws IOException {
         return objectMapper.readTree(out.toString());
@@ -109,15 +109,16 @@ public class JulLoggingTest extends AbstractEcsLoggingTest {
     @BeforeEach
     void setUp() {
         clearHandlers();
-        
+
         formatter.setIncludeOrigin(true);
         formatter.setServiceName("test");
+        formatter.setServiceVersion("1.0.0");
         formatter.setEventDataset("testdataset.log");
         formatter.setAdditionalFields("key1=value1,key2=value2");
-        
+
         Handler handler = new InMemoryStreamHandler(out, formatter);
         handler.setLevel(Level.ALL);
-        
+
         logger.addHandler(handler);
         logger.setLevel(Level.ALL);
     }
@@ -130,7 +131,7 @@ public class JulLoggingTest extends AbstractEcsLoggingTest {
         //No file.line for JUL
     }
 
-    
+
     private void clearHandlers() {
         for (Handler handler : logger.getHandlers()) {
             logger.removeHandler(handler);

--- a/log4j-ecs-layout/src/main/java/co/elastic/logging/log4j/EcsLayout.java
+++ b/log4j-ecs-layout/src/main/java/co/elastic/logging/log4j/EcsLayout.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -40,6 +40,7 @@ public class EcsLayout extends Layout {
 
     private boolean stackTraceAsArray = false;
     private String serviceName;
+    private String serviceVersion;
     private boolean includeOrigin;
     private String eventDataset;
     private List<AdditionalField> additionalFields = new ArrayList<AdditionalField>();
@@ -52,6 +53,7 @@ public class EcsLayout extends Layout {
         EcsJsonSerializer.serializeFormattedMessage(builder, event.getRenderedMessage());
         EcsJsonSerializer.serializeEcsVersion(builder);
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
+        EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadName(builder, event.getThreadName());
         EcsJsonSerializer.serializeLoggerName(builder, event.categoryName);
@@ -97,6 +99,10 @@ public class EcsLayout extends Layout {
 
     public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
+    }
+
+    public void setServiceVersion(String serviceVersion) {
+        this.serviceVersion = serviceVersion;
     }
 
     public void setIncludeOrigin(boolean includeOrigin) {

--- a/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
+++ b/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -51,6 +51,7 @@ class Log4jEcsLayoutTest extends AbstractEcsLoggingTest {
         logger.addAppender(appender);
         ecsLayout = new EcsLayout();
         ecsLayout.setServiceName("test");
+        ecsLayout.setServiceVersion("1.0.0");
         ecsLayout.setIncludeOrigin(true);
         ecsLayout.setEventDataset("testdataset.log");
         ecsLayout.activateOptions();

--- a/log4j-ecs-layout/src/test/resources/log4j.xml
+++ b/log4j-ecs-layout/src/test/resources/log4j.xml
@@ -4,6 +4,7 @@
     <appender name="List" class="co.elastic.logging.log4j.ListAppender">
         <layout class="co.elastic.logging.log4j.EcsLayout">
             <param name="serviceName" value="test"/>
+            <param name="serviceVersion" value="1.0.0"/>
             <param name="eventDataset" value="testdataset.log"/>
             <param name="includeOrigin" value="true"/>
             <param name="additionalField" value="key1=value1"/>

--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -68,14 +68,16 @@ public class EcsLayout extends AbstractStringLayout {
     private final PatternFormatter[][] fieldValuePatternFormatter;
     private final boolean stackTraceAsArray;
     private final String serviceName;
+    private final String serviceVersion;
     private final String eventDataset;
     private final boolean includeMarkers;
     private final boolean includeOrigin;
     private final ConcurrentMap<Class<? extends MultiformatMessage>, Boolean> supportsJson = new ConcurrentHashMap<Class<? extends MultiformatMessage>, Boolean>();
 
-    private EcsLayout(Configuration config, String serviceName, String eventDataset, boolean includeMarkers, KeyValuePair[] additionalFields, boolean includeOrigin, boolean stackTraceAsArray) {
+    private EcsLayout(Configuration config, String serviceName, String serviceVersion, String eventDataset, boolean includeMarkers, KeyValuePair[] additionalFields, boolean includeOrigin, boolean stackTraceAsArray) {
         super(config, UTF_8, null, null);
         this.serviceName = serviceName;
+        this.serviceVersion = serviceVersion;
         this.eventDataset = eventDataset;
         this.includeMarkers = includeMarkers;
         this.includeOrigin = includeOrigin;
@@ -125,6 +127,7 @@ public class EcsLayout extends AbstractStringLayout {
         serializeMessage(builder, gcFree, event.getMessage(), event.getThrown());
         EcsJsonSerializer.serializeEcsVersion(builder);
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
+        EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadName(builder, event.getThreadName());
         EcsJsonSerializer.serializeLoggerName(builder, event.getLoggerName());
@@ -324,6 +327,8 @@ public class EcsLayout extends AbstractStringLayout {
         private Configuration configuration;
         @PluginBuilderAttribute("serviceName")
         private String serviceName;
+        @PluginBuilderAttribute("serviceVersion")
+        private String serviceVersion;
         @PluginBuilderAttribute("eventDataset")
         private String eventDataset;
         @PluginBuilderAttribute("includeMarkers")
@@ -355,6 +360,10 @@ public class EcsLayout extends AbstractStringLayout {
             return serviceName;
         }
 
+        public String getServiceVersion() {
+            return serviceVersion;
+        }
+
         public String getEventDataset() {
             return eventDataset;
         }
@@ -382,6 +391,11 @@ public class EcsLayout extends AbstractStringLayout {
             return this;
         }
 
+        public EcsLayout.Builder setServiceVersion(final String serviceVersion) {
+            this.serviceVersion = serviceVersion;
+            return this;
+        }
+
         public EcsLayout.Builder setEventDataset(String eventDataset) {
             this.eventDataset = eventDataset;
             return this;
@@ -404,7 +418,7 @@ public class EcsLayout extends AbstractStringLayout {
 
         @Override
         public EcsLayout build() {
-            return new EcsLayout(getConfiguration(), serviceName, EcsJsonSerializer.computeEventDataset(eventDataset, serviceName), includeMarkers, additionalFields, includeOrigin, stackTraceAsArray);
+            return new EcsLayout(getConfiguration(), serviceName, serviceVersion, EcsJsonSerializer.computeEventDataset(eventDataset, serviceName), includeMarkers, additionalFields, includeOrigin, stackTraceAsArray);
         }
 
         public boolean isStackTraceAsArray() {

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
@@ -67,6 +67,7 @@ abstract class Log4j2EcsLayoutTest extends AbstractLog4j2EcsLayoutTest {
         EcsLayout ecsLayout = EcsLayout.newBuilder()
                 .setConfiguration(ctx.getConfiguration())
                 .setServiceName("test")
+                .setServiceVersion("1.0.0")
                 .setIncludeMarkers(true)
                 .setIncludeOrigin(true)
                 .setEventDataset("testdataset.log")

--- a/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
+++ b/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
@@ -5,7 +5,7 @@
     </Properties>
     <Appenders>
         <List name="TestAppender">
-            <EcsLayout serviceName="test" includeMarkers="true" includeOrigin="true" eventDataset="testdataset.log">
+            <EcsLayout serviceName="test" serviceVersion="1.0.0" includeMarkers="true" includeOrigin="true" eventDataset="testdataset.log">
                 <KeyValuePair key="cluster.uuid" value="9fe9134b-20b0-465e-acf9-8cc09ac9053b"/>
                 <KeyValuePair key="node.id" value="${node.id}"/>
                 <KeyValuePair key="empty" value="${empty}"/>

--- a/logback-ecs-encoder/src/main/java/co/elastic/logging/logback/EcsEncoder.java
+++ b/logback-ecs-encoder/src/main/java/co/elastic/logging/logback/EcsEncoder.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -45,6 +45,7 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
     private static final Charset UTF_8 = Charset.forName("UTF-8");
     private boolean stackTraceAsArray = false;
     private String serviceName;
+    private String serviceVersion;
     private String eventDataset;
     private boolean includeMarkers = false;
     private ThrowableProxyConverter throwableProxyConverter;
@@ -101,6 +102,7 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
         EcsJsonSerializer.serializeEcsVersion(builder);
         serializeMarkers(event, builder);
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
+        EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadName(builder, event.getThreadName());
         EcsJsonSerializer.serializeLoggerName(builder, event.getLoggerName());
@@ -149,6 +151,10 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
 
     public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
+    }
+
+    public void setServiceVersion(String serviceVersion) {
+        this.serviceVersion = serviceVersion;
     }
 
     public void setIncludeMarkers(boolean includeMarkers) {

--- a/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderTest.java
+++ b/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderTest.java
@@ -44,6 +44,7 @@ public class EcsEncoderTest extends AbstractEcsEncoderTest {
         logger.addAppender(appender);
         EcsEncoder ecsEncoder = new EcsEncoder();
         ecsEncoder.setServiceName("test");
+        ecsEncoder.setServiceVersion("1.0.0");
         ecsEncoder.setIncludeMarkers(true);
         ecsEncoder.setIncludeOrigin(true);
         ecsEncoder.addAdditionalField(new AdditionalField("key1", "value1"));

--- a/logback-ecs-encoder/src/test/resources/logback-config.xml
+++ b/logback-ecs-encoder/src/test/resources/logback-config.xml
@@ -3,6 +3,7 @@
     <appender name="out" class="co.elastic.logging.logback.OutputStreamAppender">
         <encoder class="co.elastic.logging.logback.EcsEncoder">
             <serviceName>test</serviceName>
+            <serviceVersion>1.0.0</serviceVersion>
             <includeMarkers>true</includeMarkers>
             <includeOrigin>true</includeOrigin>
             <topLevelLabel>top_level</topLevelLabel>


### PR DESCRIPTION
Added ECS `service.version` field support.

Refs: https://github.com/elastic/ecs-logging-java/issues/129