### PR TITLE
Add ECS console appender for spring boot

### DIFF
--- a/docs/tab-widgets/ecs-encoder.asciidoc
+++ b/docs/tab-widgets/ecs-encoder.asciidoc
@@ -11,8 +11,10 @@ In `src/main/resources/logback-spring.xml`:
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
     <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
+    <include resource="co/elastic/logging/logback/boot/ecs-console-appender.xml" />
     <include resource="co/elastic/logging/logback/boot/ecs-file-appender.xml" />
     <root level="INFO">
+        <appender-ref ref="ECS_JSON_CONSOLE"/>
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="ECS_JSON_FILE"/>
         <appender-ref ref="FILE"/>

--- a/logback-ecs-encoder/src/main/resources/co/elastic/logging/logback/boot/ecs-console-appender.xml
+++ b/logback-ecs-encoder/src/main/resources/co/elastic/logging/logback/boot/ecs-console-appender.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ECS JSON console appender logback configuration provided for import, similar to the console-appender.xml included in Spring Boot
+<include resource="co/elastic/logging/logback/boot/ecs-console-appender.xml" />
+-->
+
+<included>
+    <springProperty name="SERVICE_NAME" source="spring.application.name"/>
+    <appender name="ECS_JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="co.elastic.logging.logback.EcsEncoder">
+            <serviceName>${SERVICE_NAME:-spring-boot-application}</serviceName>
+        </encoder>
+    </appender>
+</included>


### PR DESCRIPTION
This PR adds a console appender for spring boot (https://github.com/elastic/ecs-logging-java/issues/137)