### PR TITLE
Resolves #158 - Updates the logback version

### DIFF
--- a/logback-ecs-encoder/pom.xml
+++ b/logback-ecs-encoder/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Resolves #158 

Updates the logback version

The details can be found at:

http://slf4j.org/log4shell.html

The key details are these lines:

However, logback may make JNDI calls from within its configuration file. This was recently reported in LOGBACK-1591 as a vulnerability of lesser severity. In response, we have released logback version 1.2.8. Please upgrade.