### PR TITLE
Add support for filtering stack traces in the log4j2 implementation

### DIFF
--- a/docs/tab-widgets/ecs-encoder.asciidoc
+++ b/docs/tab-widgets/ecs-encoder.asciidoc
@@ -176,6 +176,15 @@ To include any custom field in the output, use following syntax:
 
 Custom fields are included in the order they are declared. The values support https://logging.apache.org/log4j/2.x/manual/lookups.html[lookups].
 
+To suppress lines containing `com.example.SomeClass` in an exceptions stack trace, use the following syntax:
+
+[source,xml]
+----
+  <EcsLayout>
+    <StackTraceFilter filter="com.example.SomeClass" />
+  </EcsLayout>
+----
+
 NOTE: The log4j2 `EcsLayout` does not allocate any memory (unless the log event contains an `Exception`) to reduce GC pressure.
 This is achieved by manually serializing JSON so that no intermediate JSON or map representation of a log event is needed.
 // end::log4j2[]

--- a/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -182,13 +181,13 @@ class EcsJsonSerializerTest {
         } catch (Exception exception) {
             StringBuilder jsonBuilder = new StringBuilder();
             jsonBuilder.append('{');
-            List<Pattern> stackTraceFilters = List.of(Pattern.compile("\tat co.elastic.logging.EcsJsonSerializerTest.First"));
+            List<String> stackTraceFilters = List.of("co.elastic.logging.EcsJsonSerializerTest$First");
             EcsJsonSerializer.serializeException(jsonBuilder, exception, stackTraceFilters, false);
             jsonBuilder.append('}');
 
             String stackTrace = objectMapper.readTree(jsonBuilder.toString()).get(ERROR_STACK_TRACE).textValue();
             assertThat(stackTrace).contains("\n\t...\n");
-            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest.First");
+            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest$First");
         }
     }
 
@@ -199,13 +198,13 @@ class EcsJsonSerializerTest {
         } catch (Exception exception) {
             StringBuilder jsonBuilder = new StringBuilder();
             jsonBuilder.append('{');
-            List<Pattern> stackTraceFilters = List.of(Pattern.compile("\tat co.elastic.logging.EcsJsonSerializerTest.First"));
+            List<String> stackTraceFilters = List.of("co.elastic.logging.EcsJsonSerializerTest$First");
             EcsJsonSerializer.serializeException(jsonBuilder, exception, stackTraceFilters, true);
             jsonBuilder.append('}');
 
             String stackTrace = objectMapper.readTree(jsonBuilder.toString()).get(ERROR_STACK_TRACE).toString();
             assertThat(stackTrace).contains("\"\\t...\"");
-            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest.First");
+            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest$First");
         }
     }
 
@@ -216,14 +215,14 @@ class EcsJsonSerializerTest {
         } catch (Exception exception) {
             StringBuilder jsonBuilder = new StringBuilder();
             jsonBuilder.append('{');
-            List<Pattern> stackTraceFilters = List.of(Pattern.compile("\tat co.elastic.logging.EcsJsonSerializerTest.First"), Pattern.compile("\tat co.elastic.logging.EcsJsonSerializerTest.Second"));
+            List<String> stackTraceFilters = List.of("co.elastic.logging.EcsJsonSerializerTest$First", "co.elastic.logging.EcsJsonSerializerTest$Second");
             EcsJsonSerializer.serializeException(jsonBuilder, exception, stackTraceFilters, false);
             jsonBuilder.append('}');
 
             String stackTrace = objectMapper.readTree(jsonBuilder.toString()).get(ERROR_STACK_TRACE).textValue();
             assertThat(stackTrace).contains("\n\t... suppressed 2 lines\n");
-            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest.First");
-            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest.Second");
+            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest$First");
+            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest$Second");
         }
     }
 
@@ -234,14 +233,14 @@ class EcsJsonSerializerTest {
         } catch (Exception exception) {
             StringBuilder jsonBuilder = new StringBuilder();
             jsonBuilder.append('{');
-            List<Pattern> stackTraceFilters = List.of(Pattern.compile("\tat co.elastic.logging.EcsJsonSerializerTest.First"), Pattern.compile("\tat co.elastic.logging.EcsJsonSerializerTest.Second"));
+            List<String> stackTraceFilters = List.of("co.elastic.logging.EcsJsonSerializerTest$First", "co.elastic.logging.EcsJsonSerializerTest$Second");
             EcsJsonSerializer.serializeException(jsonBuilder, exception, stackTraceFilters, true);
             jsonBuilder.append('}');
 
             String stackTrace = objectMapper.readTree(jsonBuilder.toString()).get(ERROR_STACK_TRACE).toString();
             assertThat(stackTrace).contains("\"\\t... suppressed 2 lines\"");
-            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest.First");
-            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest.Second");
+            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest$First");
+            assertThat(stackTrace).doesNotContain("co.elastic.logging.EcsJsonSerializerTest$Second");
         }
     }
 

--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -57,7 +57,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.regex.Pattern;
 
 @Plugin(name = "EcsLayout", category = Node.CATEGORY, elementType = Layout.ELEMENT_TYPE)
 public class EcsLayout extends AbstractStringLayout {
@@ -71,7 +70,7 @@ public class EcsLayout extends AbstractStringLayout {
 
     private final KeyValuePair[] additionalFields;
     private final PatternFormatter[][] fieldValuePatternFormatter;
-    private final List<Pattern> stackTraceFilter;
+    private final List<String> stackTraceFilter;
     private final boolean stackTraceAsArray;
     private final String serviceName;
     private final String serviceNodeName;
@@ -81,7 +80,7 @@ public class EcsLayout extends AbstractStringLayout {
     private final ConcurrentMap<Class<? extends MultiformatMessage>, Boolean> supportsJson = new ConcurrentHashMap<Class<? extends MultiformatMessage>, Boolean>();
 
     private EcsLayout(Configuration config, String serviceName, String serviceNodeName, String eventDataset, boolean includeMarkers,
-                      KeyValuePair[] additionalFields, boolean includeOrigin, List<Pattern> stackTraceFilter, boolean stackTraceAsArray) {
+                      KeyValuePair[] additionalFields, boolean includeOrigin, List<String> stackTraceFilter, boolean stackTraceAsArray) {
         super(config, UTF_8, null, null);
         this.serviceName = serviceName;
         this.serviceNodeName = serviceNodeName;
@@ -441,9 +440,9 @@ public class EcsLayout extends AbstractStringLayout {
 
         @Override
         public EcsLayout build() {
-            List<Pattern> stackTraceFilterPatterns = new ArrayList<Pattern>(stackTraceFilters.length);
+            List<String> stackTraceFilterPatterns = new ArrayList<String>(stackTraceFilters.length);
             for (StackTraceFilter stackTraceFilter : stackTraceFilters) {
-                stackTraceFilterPatterns.add(Pattern.compile("\tat .*" + stackTraceFilter.getFilter()));
+                stackTraceFilterPatterns.add(stackTraceFilter.getFilter());
             }
             return new EcsLayout(getConfiguration(), serviceName, serviceNodeName, EcsJsonSerializer.computeEventDataset(eventDataset, serviceName),
                     includeMarkers, additionalFields, includeOrigin, stackTraceFilterPatterns, stackTraceAsArray);

--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/StackTraceFilter.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/StackTraceFilter.java
@@ -1,0 +1,58 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2022 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging.log4j2;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.status.StatusLogger;
+
+@Plugin(name = "StackTraceFilter", category = Node.CATEGORY)
+public final class StackTraceFilter {
+
+    private static final Logger LOGGER = StatusLogger.getLogger();
+
+    private final String filter;
+
+    public StackTraceFilter(String filter) {
+        this.filter = filter;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    @PluginFactory
+    public static StackTraceFilter createStackTraceFilter(@PluginAttribute("filter") final String filter) {
+        if (filter == null) {
+            LOGGER.error("StackTraceFilter must contain a filter");
+            return null;
+        }
+
+        return new StackTraceFilter(filter);
+    }
+}

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/StackTraceFilterTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/StackTraceFilterTest.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2022 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging.log4j2;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.DefaultLogEventFactory;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StackTraceFilterTest {
+
+    @Test
+    void testStackTracFilter() {
+        EcsLayout ecsLayout = new EcsLayout.Builder()
+                .setStackTraceFilters(new StackTraceFilter[]{new StackTraceFilter("co.elastic.logging.log4j2.StackTraceFilterTest")})
+                .build();
+        String formattedEvent = ecsLayout.toSerializable(createLogEvent());
+
+        assertThat(formattedEvent).contains("\\n\\t... suppressed 2 lines\\n");
+        assertThat(formattedEvent).doesNotContain("co.elastic.logging.log4j2.StackTraceFilterTest");
+    }
+
+    @Test
+    void testStackTracFilterWithStackTraceAsArray() {
+        EcsLayout ecsLayout = new EcsLayout.Builder()
+                .setStackTraceFilters(new StackTraceFilter[]{new StackTraceFilter("co.elastic.logging.log4j2.StackTraceFilterTest")})
+                .setStackTraceAsArray(true)
+                .build();
+        String formattedEvent = ecsLayout.toSerializable(createLogEvent());
+
+        assertThat(formattedEvent).contains("\"\\t... suppressed 2 lines\"");
+        assertThat(formattedEvent).doesNotContain("co.elastic.logging.log4j2.StackTraceFilterTest");
+    }
+
+    private static LogEvent createLogEvent() {
+        return new DefaultLogEventFactory().createEvent("loggerName", null, null, Level.INFO, new SimpleMessage("Something useful"), null, new Exception());
+    }
+}


### PR DESCRIPTION
This is similar to what `%xEx{filters(...)}` does.