### PR TITLE
docs: remove step 2

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -25,6 +25,9 @@ include::./tab-widgets/add-dependency-widget.asciidoc[]
 
 include::./tab-widgets/ecs-encoder-widget.asciidoc[]
 
+NOTE: If you're using the Elastic APM Java agent,
+log correlation is enabled by default starting in version 1.30.0.
+
 [float]
 [[setup-step-2]]
 === Step 2: Configure Filebeat

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -27,6 +27,8 @@ include::./tab-widgets/ecs-encoder-widget.asciidoc[]
 
 NOTE: If you're using the Elastic APM Java agent,
 log correlation is enabled by default starting in version 1.30.0.
+In previous versions, log correlation is off by default, but can be enabled by setting
+the `enable_log_correlation` config to `true`.
 
 [float]
 [[setup-step-2]]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -27,13 +27,7 @@ include::./tab-widgets/ecs-encoder-widget.asciidoc[]
 
 [float]
 [[setup-step-2]]
-=== Step 2: Enable APM log correlation (optional)
-If you are using the Elastic APM Java agent,
-set {apm-java-ref}/config-logging.html#config-enable-log-correlation[`enable_log_correlation`] to `true`.
-
-[float]
-[[setup-step-3]]
-=== Step 3: Configure Filebeat
+=== Step 2: Configure Filebeat
 
 include::{ecs-repo-dir}/setup.asciidoc[tag=configure-filebeat]
 


### PR DESCRIPTION
### Summary

Fixes the following broken links by removing step 2 from the setup guide. Log correlation is enabled by default in version 1.30:

```
08:40:20 INFO:build_docs:Bad cross-document links:
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/0.x/intro.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/0.x/setup.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/1.x/setup.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/current/setup.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
08:40:20 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs-logging/java/master/setup.html contains broken links to:
08:40:20 INFO:build_docs:   - en/apm/agent/java/current/config-logging.html#config-enable-log-correlation
```

### Downside / Question

Because only the 1.x version of the Java agent docs are published, we don't have anywhere to send users who are using 
a version > 1.30. I'm wondering if we should keep deprecated `enable_log_correlation` documentation for these users. See https://github.com/elastic/apm-agent-java/issues/2535#issuecomment-1075580099 for more context.

### Related

For https://github.com/elastic/apm-agent-java/issues/2535.

### Backport

Backport to `1.x` and `0.x`.