### PR TITLE
Use filestream instead of deprecated log input

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -47,7 +47,7 @@ But when combining the multiline settings with a `decode_json_fields` we can als
 [source,yml]
 ----
 filebeat.inputs:
-  - type: log
+  - type: filestream
     paths: /path/to/logs.json
     multiline.pattern: '^{'
     multiline.negate: true


### PR DESCRIPTION
Relates to elastic/ecs-logging#67