### PR TITLE
Configurable exception pattern for log4j2

### DIFF
--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -453,8 +453,9 @@ public class EcsLayout extends AbstractStringLayout {
             return this;
         }
 
-        public void setExceptionPattern(String exceptionPattern) {
+        public EcsLayout.Builder setExceptionPattern(String exceptionPattern) {
             this.exceptionPattern = exceptionPattern;
+            return this;
         }
 
         @Override

--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -75,10 +75,11 @@ public class EcsLayout extends AbstractStringLayout {
     private final String eventDataset;
     private final boolean includeMarkers;
     private final boolean includeOrigin;
+    private final PatternFormatter[] exceptionPatternFormatter;
     private final ConcurrentMap<Class<? extends MultiformatMessage>, Boolean> supportsJson = new ConcurrentHashMap<Class<? extends MultiformatMessage>, Boolean>();
 
     private EcsLayout(Configuration config, String serviceName, String serviceNodeName, String eventDataset, boolean includeMarkers,
-                      KeyValuePair[] additionalFields, boolean includeOrigin, boolean stackTraceAsArray) {
+                      KeyValuePair[] additionalFields, boolean includeOrigin, String exceptionPattern, boolean stackTraceAsArray) {
         super(config, UTF_8, null, null);
         this.serviceName = serviceName;
         this.serviceNodeName = serviceNodeName;
@@ -95,6 +96,14 @@ public class EcsLayout extends AbstractStringLayout {
                         .parse(additionalField.getValue())
                         .toArray(new PatternFormatter[0]);
             }
+        }
+
+        if (exceptionPattern != null && !exceptionPattern.isEmpty()) {
+            exceptionPatternFormatter = PatternLayout.createPatternParser(config)
+                    .parse(exceptionPattern)
+                    .toArray(new PatternFormatter[0]);
+        } else {
+            exceptionPatternFormatter = null;
         }
     }
 
@@ -140,7 +149,7 @@ public class EcsLayout extends AbstractStringLayout {
         if (includeOrigin) {
             EcsJsonSerializer.serializeOrigin(builder, event.getSource());
         }
-        EcsJsonSerializer.serializeException(builder, event.getThrown(), stackTraceAsArray);
+        serializeException(builder, event);
         EcsJsonSerializer.serializeObjectEnd(builder);
         return builder;
     }
@@ -325,6 +334,20 @@ public class EcsLayout extends AbstractStringLayout {
         return supportsJson;
     }
 
+    private void serializeException(StringBuilder messageBuffer, LogEvent event) {
+        Throwable thrown = event.getThrown();
+        if (thrown != null) {
+            if (exceptionPatternFormatter != null) {
+                StringBuilder builder = EcsJsonSerializer.getMessageStringBuilder();
+                formatPattern(event, exceptionPatternFormatter, builder);
+                String stackTrace = builder.toString();
+                EcsJsonSerializer.serializeException(messageBuffer, thrown.getClass().getName(), thrown.getMessage(), stackTrace, stackTraceAsArray);
+            } else {
+                EcsJsonSerializer.serializeException(messageBuffer, thrown, stackTraceAsArray);
+            }
+        }
+    }
+
     public static class Builder implements org.apache.logging.log4j.core.util.Builder<EcsLayout> {
 
         @PluginConfiguration
@@ -337,6 +360,8 @@ public class EcsLayout extends AbstractStringLayout {
         private String eventDataset;
         @PluginBuilderAttribute("includeMarkers")
         private boolean includeMarkers = false;
+        @PluginBuilderAttribute("exceptionPattern")
+        private String exceptionPattern;
         @PluginBuilderAttribute("stackTraceAsArray")
         private boolean stackTraceAsArray = false;
         @PluginElement("AdditionalField")
@@ -380,6 +405,14 @@ public class EcsLayout extends AbstractStringLayout {
             return includeOrigin;
         }
 
+        public boolean isStackTraceAsArray() {
+            return stackTraceAsArray;
+        }
+
+        public String getExceptionPattern() {
+            return exceptionPattern;
+        }
+
         /**
          * Additional fields to set on each log event.
          *
@@ -420,14 +453,14 @@ public class EcsLayout extends AbstractStringLayout {
             return this;
         }
 
+        public void setExceptionPattern(String exceptionPattern) {
+            this.exceptionPattern = exceptionPattern;
+        }
+
         @Override
         public EcsLayout build() {
             return new EcsLayout(getConfiguration(), serviceName, serviceNodeName, EcsJsonSerializer.computeEventDataset(eventDataset, serviceName),
-                    includeMarkers, additionalFields, includeOrigin, stackTraceAsArray);
-        }
-
-        public boolean isStackTraceAsArray() {
-            return stackTraceAsArray;
+                    includeMarkers, additionalFields, includeOrigin, exceptionPattern, stackTraceAsArray);
         }
     }
 }

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/CurrentLog4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/CurrentLog4j2EcsLayoutTest.java
@@ -56,6 +56,16 @@ public class CurrentLog4j2EcsLayoutTest extends Log4j2EcsLayoutTest {
         assertThat(getLastLogLine().get("baz").booleanValue()).isEqualTo(true);
     }
 
+    @Test
+    void testExceptionPattern() throws Exception {
+        error("test", new RuntimeException("test"));
+        JsonNode log = getAndValidateLastLogLine();
+        assertThat(log.get("log.level").textValue()).isIn("ERROR", "SEVERE");
+        assertThat(log.get("error.message").textValue()).isEqualTo("test");
+        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
+        assertThat(log.get("error.stack_trace").textValue().split("\\n").length).isEqualTo(4L);
+    }
+
     public static class TestClass {
         String foo;
         int bar;

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/CurrentLog4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/CurrentLog4j2EcsLayoutTest.java
@@ -56,17 +56,6 @@ public class CurrentLog4j2EcsLayoutTest extends Log4j2EcsLayoutTest {
         assertThat(getLastLogLine().get("baz").booleanValue()).isEqualTo(true);
     }
 
-    @Test
-    void testExceptionPattern() throws Exception {
-        error("test", new RuntimeException("test"));
-        JsonNode log = getAndValidateLastLogLine();
-        assertThat(log.get("log.level").textValue()).isIn("ERROR", "SEVERE");
-        assertThat(log.get("error.message").textValue()).isEqualTo("test");
-        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
-        assertThat(log.get("error.stack_trace").textValue().split("\\n").length).isEqualTo(4L);
-        assertThat(log.get("error.stack_trace").textValue()).doesNotContain("co.elastic.logging.log4j2");
-    }
-
     public static class TestClass {
         String foo;
         int bar;

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/CurrentLog4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/CurrentLog4j2EcsLayoutTest.java
@@ -64,6 +64,7 @@ public class CurrentLog4j2EcsLayoutTest extends Log4j2EcsLayoutTest {
         assertThat(log.get("error.message").textValue()).isEqualTo("test");
         assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
         assertThat(log.get("error.stack_trace").textValue().split("\\n").length).isEqualTo(4L);
+        assertThat(log.get("error.stack_trace").textValue()).doesNotContain("co.elastic.logging.log4j2");
     }
 
     public static class TestClass {

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/CustomExceptionPatternConverter.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/CustomExceptionPatternConverter.java
@@ -1,0 +1,45 @@
+package co.elastic.logging.log4j2;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.pattern.ConverterKeys;
+import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
+import org.apache.logging.log4j.core.pattern.PatternConverter;
+
+@Plugin(category = PatternConverter.CATEGORY, name = "CustomExceptionPatternConverter")
+@ConverterKeys({"cEx"})
+public class CustomExceptionPatternConverter extends LogEventPatternConverter {
+
+    public CustomExceptionPatternConverter(final String[] options) {
+        super("Custom", "custom");
+    }
+
+    public static CustomExceptionPatternConverter newInstance(final String[] options) {
+        return new CustomExceptionPatternConverter(options);
+    }
+
+
+    @Override
+    public void format(LogEvent event, StringBuilder toAppendTo) {
+        Throwable thrown = event.getThrown();
+        if (thrown != null) {
+            String message = thrown.getMessage();
+            if (message == null || message.isEmpty()) {
+                toAppendTo.append(thrown.getClass().getName())
+                        .append('\n');
+            } else {
+                toAppendTo.append(thrown.getClass().getName())
+                        .append(": ")
+                        .append(message)
+                        .append('\n');
+            }
+
+            toAppendTo.append("STACK_TRACE!");
+        }
+    }
+
+    @Override
+    public boolean handlesThrowable() {
+        return true;
+    }
+}

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithExceptionPatternTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithExceptionPatternTest.java
@@ -1,19 +1,16 @@
 package co.elastic.logging.log4j2;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
-
+public class EcsLayoutWithExceptionPatternTest extends Log4j2EcsLayoutTest {
     @Override
     protected EcsLayout.Builder configureLayout(LoggerContext context) {
         return super.configureLayout(context)
-                .setExceptionPattern("%cEx")
-                .setStackTraceAsArray(true);
+                .setExceptionPattern("%cEx");
     }
 
     @Test
@@ -23,11 +20,7 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         assertThat(log.get("log.level").textValue()).isIn("ERROR", "SEVERE");
         assertThat(log.get("error.message").textValue()).isEqualTo("test");
         assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
-        assertThat(log.get("error.stack_trace").isArray()).isTrue();
-        ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
-        assertThat(arrayNode.size()).isEqualTo(2);
-        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.RuntimeException: test");
-        assertThat(arrayNode.get(1).textValue()).isEqualTo("STACK_TRACE!");
+        assertThat(log.get("error.stack_trace").textValue()).isEqualTo("java.lang.RuntimeException: test\nSTACK_TRACE!");
     }
 
     @Test
@@ -36,10 +29,5 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         JsonNode log = getLastLogLine();;
         assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
         assertThat(log.get("error.message")).isNull();
-        assertThat(log.get("error.stack_trace").isArray()).isTrue();
-        ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
-        assertThat(arrayNode.size()).isEqualTo(2);
-        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.RuntimeException");
-        assertThat(arrayNode.get(1).textValue()).isEqualTo("STACK_TRACE!");
     }
 }

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithExceptionPatternTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithExceptionPatternTest.java
@@ -29,5 +29,6 @@ public class EcsLayoutWithExceptionPatternTest extends Log4j2EcsLayoutTest {
         JsonNode log = getLastLogLine();;
         assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
         assertThat(log.get("error.message")).isNull();
+        assertThat(log.get("error.stack_trace").textValue()).isEqualTo("java.lang.RuntimeException\nSTACK_TRACE!");
     }
 }

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithExceptionPatternTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithExceptionPatternTest.java
@@ -26,7 +26,7 @@ public class EcsLayoutWithExceptionPatternTest extends Log4j2EcsLayoutTest {
     @Test
     void testLogExceptionNullMessage() throws Exception {
         error("test", new RuntimeException());
-        JsonNode log = getLastLogLine();;
+        JsonNode log = getLastLogLine();
         assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
         assertThat(log.get("error.message")).isNull();
         assertThat(log.get("error.stack_trace").textValue()).isEqualTo("java.lang.RuntimeException\nSTACK_TRACE!");

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
@@ -1,0 +1,41 @@
+package co.elastic.logging.log4j2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
+
+    @Override
+    protected EcsLayout.Builder configureLayout(LoggerContext context) {
+        return super.configureLayout(context)
+                .setStackTraceAsArray(true);
+    }
+
+    @Test
+    void testLogException() throws Exception {
+        error("test", new RuntimeException("test"));
+        JsonNode log = getLastLogLine();
+        assertThat(log.get("log.level").textValue()).isIn("ERROR", "SEVERE");
+        assertThat(log.get("error.message").textValue()).isEqualTo("test");
+        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
+        assertThat(log.get("error.stack_trace").isArray()).isTrue();
+        ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
+        assertThat(arrayNode.size()).isEqualTo(4);
+        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.RuntimeException: test");
+        for (JsonNode element : arrayNode) {
+            assertThat(element.textValue()).doesNotContain("co.elastic.logging.log4j2");
+        }
+    }
+
+    @Test
+    void testLogExceptionNullMessage() throws Exception {
+        error("test", new RuntimeException());
+        JsonNode log = getLastLogLine();;
+        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
+        assertThat(log.get("error.message")).isNull();
+    }
+}

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
@@ -27,7 +27,7 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
         assertThat(arrayNode.size()).isEqualTo(4);
         assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.NumberFormatException: For input string: \"NOT_AN_INT\"");
-        assertThat(arrayNode.get(1).textValue()).isEqualTo("\t... suppressed 3 lines");
+        assertThat(arrayNode.get(1).textValue()).startsWith("\t... suppressed");
         assertThat(arrayNode.get(2).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.numberFormatException");
         assertThat(arrayNode.get(3).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.testLogException");
     }

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutIntegrationTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutIntegrationTest.java
@@ -29,8 +29,11 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class Log4j2EcsLayoutIntegrationTest extends AbstractLog4j2EcsLayoutTest {
     @BeforeEach

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
@@ -71,7 +71,7 @@ abstract class Log4j2EcsLayoutTest extends AbstractLog4j2EcsLayoutTest {
                 .setIncludeMarkers(true)
                 .setIncludeOrigin(true)
                 .setEventDataset("testdataset")
-                .setExceptionPattern("%ex{4}")
+                .setExceptionPattern("%rEx{4,filters(co.elastic.logging.log4j2)}")
                 .setAdditionalFields(new KeyValuePair[]{
                         new KeyValuePair("cluster.uuid", "9fe9134b-20b0-465e-acf9-8cc09ac9053b"),
                         new KeyValuePair("node.id", "${node.id}"),

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
@@ -29,7 +29,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.test.appender.ListAppender;
@@ -82,7 +81,7 @@ abstract class Log4j2EcsLayoutTest extends AbstractLog4j2EcsLayoutTest {
                 .setIncludeMarkers(true)
                 .setIncludeOrigin(true)
                 .setEventDataset("testdataset")
-                .setExceptionPattern("%rEx{4,filters(co.elastic.logging.log4j2)}")
+                .setExceptionPattern("%ex{4}")
                 .setAdditionalFields(new KeyValuePair[]{
                         new KeyValuePair("cluster.uuid", "9fe9134b-20b0-465e-acf9-8cc09ac9053b"),
                         new KeyValuePair("node.id", "${node.id}"),

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.test.appender.ListAppender;
@@ -64,8 +65,18 @@ abstract class Log4j2EcsLayoutTest extends AbstractLog4j2EcsLayoutTest {
         for (final Appender appender : root.getAppenders().values()) {
             root.removeAppender(appender);
         }
-        EcsLayout ecsLayout = EcsLayout.newBuilder()
-                .setConfiguration(ctx.getConfiguration())
+        EcsLayout ecsLayout = configureLayout(ctx)
+                .build();
+
+        listAppender = new ListAppender("ecs", null, ecsLayout, false, false);
+        listAppender.start();
+        root.addAppender(listAppender);
+        root.setLevel(Level.DEBUG);
+    }
+
+    protected EcsLayout.Builder configureLayout(LoggerContext context) {
+        return EcsLayout.newBuilder()
+                .setConfiguration(context.getConfiguration())
                 .setServiceName("test")
                 .setServiceNodeName("test-node")
                 .setIncludeMarkers(true)
@@ -81,13 +92,7 @@ abstract class Log4j2EcsLayoutTest extends AbstractLog4j2EcsLayoutTest {
                         new KeyValuePair("emptyPattern", "%notEmpty{%invalidPattern}"),
                         new KeyValuePair("key1", "value1"),
                         new KeyValuePair("key2", "value2"),
-                })
-                .build();
-
-        listAppender = new ListAppender("ecs", null, ecsLayout, false, false);
-        listAppender.start();
-        root.addAppender(listAppender);
-        root.setLevel(Level.DEBUG);
+                });
     }
 
     @AfterEach

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
@@ -71,6 +71,7 @@ abstract class Log4j2EcsLayoutTest extends AbstractLog4j2EcsLayoutTest {
                 .setIncludeMarkers(true)
                 .setIncludeOrigin(true)
                 .setEventDataset("testdataset")
+                .setExceptionPattern("%ex{4}")
                 .setAdditionalFields(new KeyValuePair[]{
                         new KeyValuePair("cluster.uuid", "9fe9134b-20b0-465e-acf9-8cc09ac9053b"),
                         new KeyValuePair("node.id", "${node.id}"),

--- a/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
+++ b/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
     <Appenders>
         <List name="TestAppender">
             <EcsLayout serviceName="test" serviceNodeName="test-node" includeMarkers="true" includeOrigin="true"
-                       eventDataset="testdataset" exceptionPattern="%rEx{4,filters(co.elastic.logging.log4j2)}">
+                       eventDataset="testdataset" exceptionPattern="%ex{4}">
                 <KeyValuePair key="cluster.uuid" value="9fe9134b-20b0-465e-acf9-8cc09ac9053b"/>
                 <KeyValuePair key="node.id" value="${node.id}"/>
                 <KeyValuePair key="empty" value="${empty}"/>

--- a/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
+++ b/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
     <Appenders>
         <List name="TestAppender">
             <EcsLayout serviceName="test" serviceNodeName="test-node" includeMarkers="true" includeOrigin="true"
-                       eventDataset="testdataset">
+                       eventDataset="testdataset" exceptionPattern="%ex{4}">
                 <KeyValuePair key="cluster.uuid" value="9fe9134b-20b0-465e-acf9-8cc09ac9053b"/>
                 <KeyValuePair key="node.id" value="${node.id}"/>
                 <KeyValuePair key="empty" value="${empty}"/>

--- a/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
+++ b/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
     <Appenders>
         <List name="TestAppender">
             <EcsLayout serviceName="test" serviceNodeName="test-node" includeMarkers="true" includeOrigin="true"
-                       eventDataset="testdataset" exceptionPattern="%ex{4}">
+                       eventDataset="testdataset" exceptionPattern="%rEx{4,filters(co.elastic.logging.log4j2)}">
                 <KeyValuePair key="cluster.uuid" value="9fe9134b-20b0-465e-acf9-8cc09ac9053b"/>
                 <KeyValuePair key="node.id" value="${node.id}"/>
                 <KeyValuePair key="empty" value="${empty}"/>


### PR DESCRIPTION
Allows configuring a throwable pattern to be used when serializing exceptions associated with the current log event.  For example, given the pattern `%ex{4}` the stack trace of the exception will be limited to the first 4 lines.  Should support any pattern supported by log4j2 including filters to suppress stack frames from specific packages.