### PR TITLE
Reduce allocations for formatting exception stack traces

### DIFF
--- a/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
@@ -279,11 +279,9 @@ public class EcsJsonSerializer {
                     continue;
                 }
 
-                // append line
-                CharSequence match = stackTrace.subSequence(index, matcher.start());
-                builder.append("\t\"");
-                JsonUtils.quoteAsString(match, builder);
-                builder.append("\",");
+                // append non-last line
+                appendStackTraceLine(builder, stackTrace, index, start);
+                builder.append(',');
                 builder.append(NEW_LINE);
                 index = end;
             } while (matcher.find());
@@ -291,20 +289,18 @@ public class EcsJsonSerializer {
             int length = stackTrace.length();
             if (index < length) {
                 // append remaining line
-                CharSequence remaining = stackTrace.subSequence(index, length);
-                builder.append("\t\"");
-                JsonUtils.quoteAsString(remaining, builder);
-                builder.append("\"");
+                appendStackTraceLine(builder, stackTrace, index, length);
             }
-
-            removeIfEndsWith(builder, NEW_LINE);
-            removeIfEndsWith(builder, ",");
         } else {
             // no newlines found, add entire stack trace as single element
-            builder.append("\t\"");
-            JsonUtils.quoteAsString(stackTrace, builder);
-            builder.append("\"");
+            appendStackTraceLine(builder, stackTrace, 0, stackTrace.length());
         }
+    }
+
+    private static void appendStackTraceLine(StringBuilder builder, CharSequence stackTrace, int start, int end) {
+        builder.append("\t\"");
+        JsonUtils.quoteAsString(stackTrace, start, end, builder);
+        builder.append("\"");
     }
 
     public static void removeIfEndsWith(StringBuilder sb, String ending) {

--- a/ecs-logging-core/src/main/java/co/elastic/logging/JsonUtils.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/JsonUtils.java
@@ -62,9 +62,17 @@ public final class JsonUtils {
             sb.append("null");
             return;
         }
+        quoteAsString(content, 0, content.length(), sb);
+    }
+
+    public static void quoteAsString(CharSequence content, int start, int end, StringBuilder sb) {
+        if (content == null) {
+            sb.append("null");
+            return;
+        }
         final int[] escCodes = sOutputEscapes128;
         final int escLen = escCodes.length;
-        for (int i = 0, len = content.length(); i < len; ++i) {
+        for (int i = start; i < end; ++i) {
             char c = content.charAt(i);
             if (c >= escLen || escCodes[c] == 0) {
                 sb.append(c);

--- a/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
@@ -148,10 +148,28 @@ class EcsJsonSerializerTest {
         jsonBuilder.append('}');
 
         JsonNode jsonNode = objectMapper.readTree(jsonBuilder.toString());
+        System.out.println(jsonNode.toPrettyString());
         assertThat(jsonNode.get(ERROR_TYPE).textValue()).isEqualTo("className");
         assertThat(jsonNode.get(ERROR_STACK_TRACE).isArray()).isTrue();
+        assertThat(jsonNode.get(ERROR_STACK_TRACE).size()).isEqualTo(2);
         assertThat(jsonNode.get(ERROR_STACK_TRACE).get(0).textValue()).isEqualTo("stacktrace");
         assertThat(jsonNode.get(ERROR_STACK_TRACE).get(1).textValue()).isEqualTo("caused by error");
+        assertThat(jsonNode.get(ERROR_MESSAGE).textValue()).isEqualTo("message");
+    }
+
+    @Test
+    void serializeExceptionWithSingleLineStackTraceAsArray() throws JsonProcessingException {
+        StringBuilder jsonBuilder = new StringBuilder();
+        jsonBuilder.append('{');
+        EcsJsonSerializer.serializeException(jsonBuilder, "className", "message", "caused by error", true);
+        jsonBuilder.append('}');
+        System.out.println(jsonBuilder);
+        JsonNode jsonNode = objectMapper.readTree(jsonBuilder.toString());
+        System.out.println(jsonNode.toPrettyString());
+        assertThat(jsonNode.get(ERROR_TYPE).textValue()).isEqualTo("className");
+        assertThat(jsonNode.get(ERROR_STACK_TRACE).isArray()).isTrue();
+        assertThat(jsonNode.get(ERROR_STACK_TRACE).size()).isEqualTo(1);
+        assertThat(jsonNode.get(ERROR_STACK_TRACE).get(0).textValue()).isEqualTo("caused by error");
         assertThat(jsonNode.get(ERROR_MESSAGE).textValue()).isEqualTo("message");
     }
 


### PR DESCRIPTION
Reduces the number of allocations when formatting exception stack traces.

1. Accepts a `CharSequence` instead of a `String` so that an underlying `StringBuilder` can be passed directly without requiring an intermediate allocation.
2. Reimplements `EcsJsonSerializer#formatStackTraceAsArray` to use `Matcher` to iterate over the `CharSequence` to avoid allocating the `ArrayList<String>`, `String[]` and each individual `String` element.