### PR TITLE
JUL - fix loading of boolean configs

### DIFF
--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
@@ -51,9 +51,8 @@ public class EcsFormatter extends Formatter {
     public EcsFormatter() {
         serviceName = getProperty("co.elastic.logging.jul.EcsFormatter.serviceName", null);
         serviceNodeName = getProperty("co.elastic.logging.jul.EcsFormatter.serviceNodeName", null);
-        includeOrigin = Boolean.getBoolean(getProperty("co.elastic.logging.jul.EcsFormatter.includeOrigin", "false"));
-        stackTraceAsArray = Boolean
-                .getBoolean(getProperty("co.elastic.logging.jul.EcsFormatter.stackTraceAsArray", "false"));
+        includeOrigin = Boolean.parseBoolean(getProperty("co.elastic.logging.jul.EcsFormatter.includeOrigin", "false"));
+        stackTraceAsArray = Boolean.parseBoolean(getProperty("co.elastic.logging.jul.EcsFormatter.stackTraceAsArray", "false"));
         eventDataset = getProperty("co.elastic.logging.jul.EcsFormatter.eventDataset", null);
         eventDataset = EcsJsonSerializer.computeEventDataset(eventDataset, serviceName);
         setAdditionalFields(getProperty("co.elastic.logging.jul.EcsFormatter.additionalFields", null));

--- a/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulIntegrationTest.java
+++ b/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulIntegrationTest.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2022 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.logging.jul;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.logging.LogManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests logging setup based on a custom logging.properties file, as well as Exception stack trace formatting as array
+ */
+public class JulIntegrationTest extends JulLoggingTest {
+    @BeforeEach
+    void setUp() throws IOException {
+        LogManager.getLogManager().readConfiguration(getClass().getClassLoader().getResourceAsStream("logging.properties"));
+        super.setUpFormatter();
+    }
+
+    @Override
+    protected EcsFormatter createEcsFormatter() {
+        // relying on the configuration loaded from the logging.properties file
+        return new EcsFormatter();
+    }
+
+    @Test
+    void testLogException() throws Exception {
+        error("test", new RuntimeException("test"));
+        JsonNode log = getLastLogLine();
+        assertThat(log.get("log.level").textValue()).isIn("ERROR", "SEVERE");
+        assertThat(log.get("error.message").textValue()).isEqualTo("test");
+        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
+        assertThat(log.get("error.stack_trace").isArray()).isTrue();
+        assertThat(log.get("error.stack_trace").get(0).textValue()).isEqualTo("java.lang.RuntimeException: test");
+        assertThat(log.get("error.stack_trace").get(1).textValue()).contains("at co.elastic.logging.jul.JulIntegrationTest");
+    }
+
+    @Test
+    void testLogExceptionNullMessage() throws Exception {
+        error("test", new RuntimeException());
+        JsonNode log = getLastLogLine();
+        assertThat(log.get("error.message")).isNull();
+        assertThat(log.get("error.type").textValue()).isEqualTo(RuntimeException.class.getName());
+        assertThat(log.get("error.stack_trace").get(0).textValue()).isEqualTo("java.lang.RuntimeException");
+        assertThat(log.get("error.stack_trace").get(1).textValue()).contains("at co.elastic.logging.jul.JulIntegrationTest");
+    }
+}

--- a/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTest.java
+++ b/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;
+import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.StreamHandler;
@@ -109,25 +110,31 @@ public class JulLoggingTest extends AbstractEcsLoggingTest {
     }
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
+        // loads configuration based on the default logging.properties file
+        LogManager.getLogManager().readConfiguration();
         setUpFormatter();
         formatter.setAdditionalFields("key1=value1,key2=value2");
     }
 
-    private void setUpFormatter() {
+    protected void setUpFormatter() {
         clearHandlers();
-
-        formatter = new EcsFormatter();
-        formatter.setIncludeOrigin(true);
-        formatter.setServiceName("test");
-        formatter.setServiceNodeName("test-node");
-        formatter.setEventDataset("testdataset");
+        formatter = createEcsFormatter();
 
         Handler handler = new InMemoryStreamHandler(out, formatter);
         handler.setLevel(Level.ALL);
 
         logger.addHandler(handler);
         logger.setLevel(Level.ALL);
+    }
+
+    protected EcsFormatter createEcsFormatter() {
+        EcsFormatter ret = new EcsFormatter();
+        ret.setIncludeOrigin(true);
+        ret.setServiceName("test");
+        ret.setServiceNodeName("test-node");
+        ret.setEventDataset("testdataset");
+        return ret;
     }
 
     @Test

--- a/jul-ecs-formatter/src/test/resources/logging.properties
+++ b/jul-ecs-formatter/src/test/resources/logging.properties
@@ -1,5 +1,6 @@
 # ECS formatter
 co.elastic.logging.jul.EcsFormatter.serviceName=test
+co.elastic.logging.jul.EcsFormatter.serviceVersion=test-version
 co.elastic.logging.jul.EcsFormatter.serviceNodeName=test-node
 co.elastic.logging.jul.EcsFormatter.eventDataset=testdataset
 co.elastic.logging.jul.EcsFormatter.includeOrigin=true

--- a/jul-ecs-formatter/src/test/resources/logging.properties
+++ b/jul-ecs-formatter/src/test/resources/logging.properties
@@ -1,0 +1,7 @@
+# ECS formatter
+co.elastic.logging.jul.EcsFormatter.serviceName=test
+co.elastic.logging.jul.EcsFormatter.serviceNodeName=test-node
+co.elastic.logging.jul.EcsFormatter.eventDataset=testdataset
+co.elastic.logging.jul.EcsFormatter.includeOrigin=true
+co.elastic.logging.jul.EcsFormatter.stackTraceAsArray=true
+co.elastic.logging.jul.EcsFormatter.additionalFields=key1=value1,key2=value2


### PR DESCRIPTION
Fixes #133 
Adds a JUL integration test that fails without this fix and adds testing for Exception stack trace formatting as array.