### PR TITLE
Add support for service.environment

### DIFF
--- a/docs/tab-widgets/ecs-encoder.asciidoc
+++ b/docs/tab-widgets/ecs-encoder.asciidoc
@@ -42,6 +42,7 @@ All you have to do is to use the `co.elastic.logging.logback.EcsEncoder` instead
 <encoder class="co.elastic.logging.logback.EcsEncoder">
     <serviceName>my-application</serviceName>
     <serviceVersion>my-application-version</serviceVersion>
+    <serviceEnvironment>my-application-environment</serviceEnvironment>
     <serviceNodeName>my-application-cluster-node</serviceNodeName>
 </encoder>
 ----
@@ -60,6 +61,11 @@ All you have to do is to use the `co.elastic.logging.logback.EcsEncoder` instead
 |String
 |
 |Sets the `service.version` field so you can filter your logs by a particular service version
+
+|`serviceEnvironment`
+|String
+|
+|Sets the `service.environment` field so you can filter your logs by a particular service environment
 
 |`serviceNodeName`
 |String
@@ -116,10 +122,10 @@ For example:
 <Configuration status="DEBUG">
     <Appenders>
         <Console name="LogToConsole" target="SYSTEM_OUT">
-            <EcsLayout serviceName="my-app" serviceVersion="my-app-version" serviceNodeName="my-app-cluster-node"/>
+            <EcsLayout serviceName="my-app" serviceVersion="my-app-version" serviceEnvironment="my-app-environment" serviceNodeName="my-app-cluster-node"/>
         </Console>
         <File name="LogToFile" fileName="logs/app.log">
-            <EcsLayout serviceName="my-app" serviceVersion="my-app-version" serviceNodeName="my-app-cluster-node"/>
+            <EcsLayout serviceName="my-app" serviceVersion="my-app-version" serviceEnvironment="my-app-environment" serviceNodeName="my-app-cluster-node"/>
         </File>
     </Appenders>
     <Loggers>
@@ -145,6 +151,11 @@ For example:
 |String
 |
 |Sets the `service.version` field so you can filter your logs by a particular service version
+
+|`serviceEnvironment`
+|String
+|
+|Sets the `service.environment` field so you can filter your logs by a particular service environment
 
 |`serviceNodeName`
 |String
@@ -238,6 +249,11 @@ For example:
 |
 |Sets the `service.version` field so you can filter your logs by a particular service version
 
+|`serviceEnvironment`
+|String
+|
+|Sets the `service.environment` field so you can filter your logs by a particular service environment
+
 |`serviceNodeName`
 |String
 |
@@ -286,6 +302,7 @@ java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = co.elastic.logging.jul.EcsFormatter
 co.elastic.logging.jul.EcsFormatter.serviceName=my-app
 co.elastic.logging.jul.EcsFormatter.serviceVersion=my-app-version
+co.elastic.logging.jul.EcsFormatter.serviceEnvironment=my-app-environment
 co.elastic.logging.jul.EcsFormatter.serviceNodeName=my-app-cluster-node
 ----
 
@@ -303,6 +320,11 @@ co.elastic.logging.jul.EcsFormatter.serviceNodeName=my-app-cluster-node
 |String
 |
 |Sets the `service.version` field so you can filter your logs by a particular service version
+
+|`serviceEnvironment`
+|String
+|
+|Sets the `service.environment` field so you can filter your logs by a particular service environment
 
 |`serviceNodeName`
 |String
@@ -350,7 +372,7 @@ Add the formatter to a handler in the logging subsystem:
 [source,bash]
 ----
 $WILDFLY_HOME/bin/jboss-cli.sh -c '/subsystem=logging/custom-formatter=ECS:add(module=co.elastic.logging.jboss-logmanager-ecs-formatter,
-class=co.elastic.logging.jboss.logmanager.EcsFormatter, properties={serviceName=my-app,serviceVersion=my-app-version,serviceNodeName=my-app-cluster-node}),\
+class=co.elastic.logging.jboss.logmanager.EcsFormatter, properties={serviceName=my-app,serviceVersion=my-app-version,serviceEnvironment=my-app-environment,serviceNodeName=my-app-cluster-node}),\
                                    /subsystem=logging/console-handler=CONSOLE:write-attribute(name=named-formatter,value=ECS)'
 ----
 
@@ -368,6 +390,11 @@ class=co.elastic.logging.jboss.logmanager.EcsFormatter, properties={serviceName=
 |String
 |
 |Sets the `service.version` field so you can filter your logs by a particular service version
+
+|`serviceEnvironment`
+|String
+|
+|Sets the `service.environment` field so you can filter your logs by a particular service environment
 
 |`serviceNodeName`
 |String

--- a/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
@@ -36,7 +36,7 @@ public class EcsJsonSerializer {
     private static final TimestampSerializer TIMESTAMP_SERIALIZER = new TimestampSerializer();
     private static final ThreadLocal<StringBuilder> messageStringBuilder = new ThreadLocal<StringBuilder>();
     private static final String NEW_LINE = System.getProperty("line.separator");
-    private static final Pattern NEW_LINE_PATTERN = Pattern.compile("\\R");
+    private static final Pattern NEW_LINE_PATTERN = Pattern.compile("\\r\\n|\\n|\\r");
 
     public static CharSequence toNullSafeString(final CharSequence s) {
         return s == null ? "" : s;

--- a/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
@@ -103,6 +103,14 @@ public class EcsJsonSerializer {
         }
     }
 
+    public static void serializeServiceEnvironment(StringBuilder builder, String serviceEnvironment) {
+        if (serviceEnvironment != null) {
+            builder.append("\"service.environment\":\"");
+            JsonUtils.quoteAsString(serviceEnvironment, builder);
+            builder.append("\",");
+        }
+    }
+
     public static void serializeServiceNodeName(StringBuilder builder, String serviceNodeName) {
         if (serviceNodeName != null) {
             builder.append("\"service.node.name\":\"");

--- a/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
+++ b/ecs-logging-core/src/main/java/co/elastic/logging/EcsJsonSerializer.java
@@ -36,7 +36,7 @@ public class EcsJsonSerializer {
     private static final TimestampSerializer TIMESTAMP_SERIALIZER = new TimestampSerializer();
     private static final ThreadLocal<StringBuilder> messageStringBuilder = new ThreadLocal<StringBuilder>();
     private static final String NEW_LINE = System.getProperty("line.separator");
-    private static final Pattern NEW_LINE_PATTERN = Pattern.compile("\\n");
+    private static final Pattern NEW_LINE_PATTERN = Pattern.compile("\\R");
 
     public static CharSequence toNullSafeString(final CharSequence s) {
         return s == null ? "" : s;

--- a/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/AbstractEcsLoggingTest.java
@@ -60,6 +60,7 @@ public abstract class AbstractEcsLoggingTest {
         assertThat(logLine.get("process.thread.name").textValue()).isEqualTo(Thread.currentThread().getName());
         assertThat(logLine.get("service.name").textValue()).isEqualTo("test");
         assertThat(logLine.get("service.version").textValue()).isEqualTo("test-version");
+        assertThat(logLine.get("service.environment").textValue()).isEqualTo("test-environment");
         assertThat(logLine.get("service.node.name").textValue()).isEqualTo("test-node");
         assertThat(Instant.parse(logLine.get("@timestamp").textValue())).isCloseTo(Instant.now(), within(1, ChronoUnit.MINUTES));
         assertThat(logLine.get("log.level").textValue()).isIn("DEBUG", "FINE");

--- a/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
+++ b/ecs-logging-core/src/test/java/co/elastic/logging/EcsJsonSerializerTest.java
@@ -66,6 +66,7 @@ class EcsJsonSerializerTest {
         String loggerName = "logger\"";
         String serviceName = "test\"";
         String serviceVersion = "test-version\"";
+        String serviceEnvironment = "test-environment\"";
         String serviceNodeName = "test-node\"";
         String eventDataset = "event-dataset\"";
         String threadName = "event-dataset\"";
@@ -77,6 +78,7 @@ class EcsJsonSerializerTest {
         EcsJsonSerializer.serializeLoggerName(jsonBuilder, loggerName);
         EcsJsonSerializer.serializeServiceName(jsonBuilder, serviceName);
         EcsJsonSerializer.serializeServiceVersion(jsonBuilder, serviceVersion);
+        EcsJsonSerializer.serializeServiceEnvironment(jsonBuilder, serviceEnvironment);
         EcsJsonSerializer.serializeServiceNodeName(jsonBuilder, serviceNodeName);
         EcsJsonSerializer.serializeEventDataset(jsonBuilder, eventDataset);
         EcsJsonSerializer.serializeThreadName(jsonBuilder, threadName);
@@ -88,6 +90,7 @@ class EcsJsonSerializerTest {
         assertThat(jsonNode.get("log.logger").textValue()).isEqualTo(loggerName);
         assertThat(jsonNode.get("service.name").textValue()).isEqualTo(serviceName);
         assertThat(jsonNode.get("service.version").textValue()).isEqualTo(serviceVersion);
+        assertThat(jsonNode.get("service.environment").textValue()).isEqualTo(serviceEnvironment);
         assertThat(jsonNode.get("service.node.name").textValue()).isEqualTo(serviceNodeName);
         assertThat(jsonNode.get("event.dataset").textValue()).isEqualTo(eventDataset);
         assertThat(jsonNode.get("process.thread.name").textValue()).isEqualTo(eventDataset);

--- a/jboss-logmanager-ecs-formatter/src/main/java/co/elastic/logging/jboss/logmanager/EcsFormatter.java
+++ b/jboss-logmanager-ecs-formatter/src/main/java/co/elastic/logging/jboss/logmanager/EcsFormatter.java
@@ -37,6 +37,7 @@ public class EcsFormatter extends ExtFormatter {
 
     private String serviceName;
     private String serviceVersion;
+    private String serviceEnvironment;
     private String serviceNodeName;
     private String eventDataset;
     private List<AdditionalField> additionalFields = Collections.emptyList();
@@ -45,7 +46,8 @@ public class EcsFormatter extends ExtFormatter {
 
     public EcsFormatter() {
         serviceName = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.serviceName", null);
-        serviceVersion = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.serviceversion", null);
+        serviceVersion = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.serviceVersion", null);
+        serviceEnvironment = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.serviceEnvironment", null);
         serviceNodeName = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.serviceNodeName", null);
         eventDataset = getProperty("co.elastic.logging.jboss.logmanager.EcsFormatter.eventDataset", null);
         eventDataset = EcsJsonSerializer.computeEventDataset(eventDataset, serviceName);
@@ -62,6 +64,7 @@ public class EcsFormatter extends ExtFormatter {
         EcsJsonSerializer.serializeEcsVersion(builder);
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
         EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
+        EcsJsonSerializer.serializeServiceEnvironment(builder, serviceEnvironment);
         EcsJsonSerializer.serializeServiceNodeName(builder, serviceNodeName);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadName(builder, record.getThreadName());
@@ -98,6 +101,10 @@ public class EcsFormatter extends ExtFormatter {
 
     public void setServiceVersion(final String serviceVersion) {
         this.serviceVersion = serviceVersion;
+    }
+
+    public void setServiceEnvironment(final String serviceEnvironment) {
+        this.serviceEnvironment = serviceEnvironment;
     }
 
     public void setServiceNodeName(final String serviceNodeName) {

--- a/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/EcsFormatterTest.java
+++ b/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/EcsFormatterTest.java
@@ -85,8 +85,8 @@ class EcsFormatterTest {
         assertThat(result.get("error.type").textValue()).isEqualTo("co.elastic.logging.jboss.logmanager.EcsFormatterTest$1");
         assertThat(result.get("error.message").textValue()).isEqualTo("Example Exception Message");
         assertThat(result.get("error.stack_trace").textValue())
-                .isEqualTo("co.elastic.logging.jboss.logmanager.EcsFormatterTest$1: Example Exception Message\n" +
-                        "\tat co.elastic.logging.jboss.logmanager.EcsFormatterTest.testExceptionLogging(EcsFormatterTest.java:125)\n");
+                .isEqualTo("co.elastic.logging.jboss.logmanager.EcsFormatterTest$1: Example Exception Message" + System.lineSeparator() +
+                        "\tat co.elastic.logging.jboss.logmanager.EcsFormatterTest.testExceptionLogging(EcsFormatterTest.java:125)" + System.lineSeparator());
     }
 }
 

--- a/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/JBossLogManagerTest.java
+++ b/jboss-logmanager-ecs-formatter/src/test/java/co/elastic/logging/jboss/logmanager/JBossLogManagerTest.java
@@ -90,6 +90,7 @@ class JBossLogManagerTest extends AbstractEcsLoggingTest {
         formatter.setIncludeOrigin(true);
         formatter.setServiceName("test");
         formatter.setServiceVersion("test-version");
+        formatter.setServiceEnvironment("test-environment");
         formatter.setServiceNodeName("test-node");
         formatter.setEventDataset("testdataset");
         formatter.setAdditionalFields("key1=value1,key2=value2");

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
@@ -41,7 +41,6 @@ public class EcsFormatter extends Formatter {
     private boolean stackTraceAsArray;
     private String serviceName;
     private String serviceVersion;
-
     private String serviceEnvironment;
     private String serviceNodeName;
     private boolean includeOrigin;

--- a/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
+++ b/jul-ecs-formatter/src/main/java/co/elastic/logging/jul/EcsFormatter.java
@@ -41,6 +41,8 @@ public class EcsFormatter extends Formatter {
     private boolean stackTraceAsArray;
     private String serviceName;
     private String serviceVersion;
+
+    private String serviceEnvironment;
     private String serviceNodeName;
     private boolean includeOrigin;
     private String eventDataset;
@@ -52,6 +54,7 @@ public class EcsFormatter extends Formatter {
     public EcsFormatter() {
         serviceName = getProperty("co.elastic.logging.jul.EcsFormatter.serviceName", null);
         serviceVersion= getProperty("co.elastic.logging.jul.EcsFormatter.serviceVersion", null);
+        serviceEnvironment= getProperty("co.elastic.logging.jul.EcsFormatter.serviceEnvironment", null);
         serviceNodeName = getProperty("co.elastic.logging.jul.EcsFormatter.serviceNodeName", null);
         includeOrigin = Boolean.parseBoolean(getProperty("co.elastic.logging.jul.EcsFormatter.includeOrigin", "false"));
         stackTraceAsArray = Boolean.parseBoolean(getProperty("co.elastic.logging.jul.EcsFormatter.stackTraceAsArray", "false"));
@@ -71,6 +74,7 @@ public class EcsFormatter extends Formatter {
         EcsJsonSerializer.serializeMDC(builder, mdcSupplier.getMDC());
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
         EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
+        EcsJsonSerializer.serializeServiceEnvironment(builder, serviceEnvironment);
         EcsJsonSerializer.serializeServiceNodeName(builder, serviceNodeName);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         if (Thread.currentThread().getId() == record.getThreadID()) {
@@ -100,6 +104,10 @@ public class EcsFormatter extends Formatter {
 
     public void setServiceVersion(final String serviceVersion) {
         this.serviceVersion = serviceVersion;
+    }
+
+    public void setServiceEnvironment(final String serviceEnvironment) {
+        this.serviceEnvironment = serviceEnvironment;
     }
 
     public void setServiceNodeName(final String serviceNodeName) {

--- a/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTest.java
+++ b/jul-ecs-formatter/src/test/java/co/elastic/logging/jul/JulLoggingTest.java
@@ -133,6 +133,7 @@ public class JulLoggingTest extends AbstractEcsLoggingTest {
         ret.setIncludeOrigin(true);
         ret.setServiceName("test");
         ret.setServiceVersion("test-version");
+        ret.setServiceEnvironment("test-environment");
         ret.setServiceNodeName("test-node");
         ret.setEventDataset("testdataset");
         return ret;

--- a/jul-ecs-formatter/src/test/resources/logging.properties
+++ b/jul-ecs-formatter/src/test/resources/logging.properties
@@ -1,6 +1,7 @@
 # ECS formatter
 co.elastic.logging.jul.EcsFormatter.serviceName=test
 co.elastic.logging.jul.EcsFormatter.serviceVersion=test-version
+co.elastic.logging.jul.EcsFormatter.serviceEnvironment=test-environment
 co.elastic.logging.jul.EcsFormatter.serviceNodeName=test-node
 co.elastic.logging.jul.EcsFormatter.eventDataset=testdataset
 co.elastic.logging.jul.EcsFormatter.includeOrigin=true

--- a/log4j-ecs-layout/src/main/java/co/elastic/logging/log4j/EcsLayout.java
+++ b/log4j-ecs-layout/src/main/java/co/elastic/logging/log4j/EcsLayout.java
@@ -41,6 +41,8 @@ public class EcsLayout extends Layout {
     private boolean stackTraceAsArray = false;
     private String serviceName;
     private String serviceVersion;
+
+    private String serviceEnvironment;
     private String serviceNodeName;
     private boolean includeOrigin;
     private String eventDataset;
@@ -55,6 +57,7 @@ public class EcsLayout extends Layout {
         EcsJsonSerializer.serializeEcsVersion(builder);
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
         EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
+        EcsJsonSerializer.serializeServiceEnvironment(builder, serviceEnvironment);
         EcsJsonSerializer.serializeServiceNodeName(builder, serviceNodeName);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadName(builder, event.getThreadName());
@@ -105,6 +108,10 @@ public class EcsLayout extends Layout {
 
     public void setServiceVersion(String serviceVersion) {
         this.serviceVersion = serviceVersion;
+    }
+
+    public void setServiceEnvironment(String serviceEnvironment) {
+        this.serviceEnvironment = serviceEnvironment;
     }
 
     public void setServiceNodeName(String serviceNodeName) {

--- a/log4j-ecs-layout/src/main/java/co/elastic/logging/log4j/EcsLayout.java
+++ b/log4j-ecs-layout/src/main/java/co/elastic/logging/log4j/EcsLayout.java
@@ -41,7 +41,6 @@ public class EcsLayout extends Layout {
     private boolean stackTraceAsArray = false;
     private String serviceName;
     private String serviceVersion;
-
     private String serviceEnvironment;
     private String serviceNodeName;
     private boolean includeOrigin;

--- a/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
+++ b/log4j-ecs-layout/src/test/java/co/elastic/logging/log4j/Log4jEcsLayoutTest.java
@@ -52,6 +52,7 @@ class Log4jEcsLayoutTest extends AbstractEcsLoggingTest {
         ecsLayout = new EcsLayout();
         ecsLayout.setServiceName("test");
         ecsLayout.setServiceVersion("test-version");
+        ecsLayout.setServiceEnvironment("test-environment");
         ecsLayout.setServiceNodeName("test-node");
         ecsLayout.setIncludeOrigin(true);
         ecsLayout.setEventDataset("testdataset");

--- a/log4j-ecs-layout/src/test/resources/log4j.xml
+++ b/log4j-ecs-layout/src/test/resources/log4j.xml
@@ -5,6 +5,7 @@
         <layout class="co.elastic.logging.log4j.EcsLayout">
             <param name="serviceName" value="test"/>
             <param name="serviceVersion" value="test-version"/>
+            <param name="serviceEnvironment" value="test-environment"/>
             <param name="serviceNodeName" value="test-node"/>
             <param name="eventDataset" value="testdataset"/>
             <param name="includeOrigin" value="true"/>

--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -72,6 +72,8 @@ public class EcsLayout extends AbstractStringLayout {
     private final boolean stackTraceAsArray;
     private final String serviceName;
     private final String serviceVersion;
+
+    private final String serviceEnvironment;
     private final String serviceNodeName;
     private final String eventDataset;
     private final boolean includeMarkers;
@@ -79,11 +81,12 @@ public class EcsLayout extends AbstractStringLayout {
     private final PatternFormatter[] exceptionPatternFormatter;
     private final ConcurrentMap<Class<? extends MultiformatMessage>, Boolean> supportsJson = new ConcurrentHashMap<Class<? extends MultiformatMessage>, Boolean>();
 
-    private EcsLayout(Configuration config, String serviceName, String serviceVersion, String serviceNodeName, String eventDataset, boolean includeMarkers,
+    private EcsLayout(Configuration config, String serviceName, String serviceVersion, String serviceEnvironment, String serviceNodeName, String eventDataset, boolean includeMarkers,
                       KeyValuePair[] additionalFields, boolean includeOrigin, String exceptionPattern, boolean stackTraceAsArray) {
         super(config, UTF_8, null, null);
         this.serviceName = serviceName;
         this.serviceVersion = serviceVersion;
+        this.serviceEnvironment = serviceEnvironment;
         this.serviceNodeName = serviceNodeName;
         this.eventDataset = eventDataset;
         this.includeMarkers = includeMarkers;
@@ -143,6 +146,7 @@ public class EcsLayout extends AbstractStringLayout {
         EcsJsonSerializer.serializeEcsVersion(builder);
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
         EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
+        EcsJsonSerializer.serializeServiceEnvironment(builder, serviceEnvironment);
         EcsJsonSerializer.serializeServiceNodeName(builder, serviceNodeName);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadName(builder, event.getThreadName());
@@ -358,6 +362,8 @@ public class EcsLayout extends AbstractStringLayout {
         private String serviceName;
         @PluginBuilderAttribute("serviceVersion")
         private String serviceVersion;
+        @PluginBuilderAttribute("serviceEnvironment")
+        private String serviceEnvironment;
         @PluginBuilderAttribute("serviceNodeName")
         private String serviceNodeName;
         @PluginBuilderAttribute("eventDataset")
@@ -396,6 +402,8 @@ public class EcsLayout extends AbstractStringLayout {
         public String getServiceVersion() {
             return serviceVersion;
         }
+
+        public String getServiceEnvironment() { return serviceEnvironment; }
 
         public String getServiceNodeName() {
             return serviceNodeName;
@@ -441,6 +449,11 @@ public class EcsLayout extends AbstractStringLayout {
             return this;
         }
 
+        public EcsLayout.Builder setServiceEnvironment(final String serviceEnvironment) {
+            this.serviceEnvironment = serviceEnvironment;
+            return this;
+        }
+
         public EcsLayout.Builder setServiceNodeName(final String serviceNodeName) {
             this.serviceNodeName = serviceNodeName;
             return this;
@@ -473,7 +486,8 @@ public class EcsLayout extends AbstractStringLayout {
 
         @Override
         public EcsLayout build() {
-            return new EcsLayout(getConfiguration(), serviceName, serviceVersion, serviceNodeName, EcsJsonSerializer.computeEventDataset(eventDataset, serviceName),
+            return new EcsLayout(getConfiguration(), serviceName, serviceVersion, serviceEnvironment, serviceNodeName,
+                    EcsJsonSerializer.computeEventDataset(eventDataset, serviceName),
                     includeMarkers, additionalFields, includeOrigin, exceptionPattern, stackTraceAsArray);
         }
     }

--- a/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
+++ b/log4j2-ecs-layout/src/main/java/co/elastic/logging/log4j2/EcsLayout.java
@@ -72,7 +72,6 @@ public class EcsLayout extends AbstractStringLayout {
     private final boolean stackTraceAsArray;
     private final String serviceName;
     private final String serviceVersion;
-
     private final String serviceEnvironment;
     private final String serviceNodeName;
     private final String eventDataset;

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
@@ -50,7 +50,7 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         assertThat(log.get("error.stack_trace").isArray()).isTrue();
         ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
         assertThat(arrayNode.size()).isEqualTo(4);
-        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.NumberFormatException: For input string: \"NOT_AN_INT\"");
+        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.NumberFormatException: For input string: \"NOT_AN_INT\"\r");
         assertThat(arrayNode.get(1).textValue()).startsWith("\t... suppressed");
         assertThat(arrayNode.get(2).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.numberFormatException");
         assertThat(arrayNode.get(3).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.testLogException");
@@ -75,7 +75,7 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         assertThat(log.get("error.stack_trace").isArray()).isTrue();
         ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
         assertThat(arrayNode.size()).isEqualTo(4);
-        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.RuntimeException");
+        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.RuntimeException\r");
         assertThat(arrayNode.get(1).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.testLogExceptionNullMessage");
     }
 }

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
@@ -50,7 +50,7 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         assertThat(log.get("error.stack_trace").isArray()).isTrue();
         ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
         assertThat(arrayNode.size()).isEqualTo(4);
-        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.NumberFormatException: For input string: \"NOT_AN_INT\"\r");
+        assertThat(arrayNode.get(0).textValue().trim()).isEqualTo("java.lang.NumberFormatException: For input string: \"NOT_AN_INT\"");
         assertThat(arrayNode.get(1).textValue()).startsWith("\t... suppressed");
         assertThat(arrayNode.get(2).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.numberFormatException");
         assertThat(arrayNode.get(3).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.testLogException");
@@ -75,7 +75,7 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         assertThat(log.get("error.stack_trace").isArray()).isTrue();
         ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
         assertThat(arrayNode.size()).isEqualTo(4);
-        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.RuntimeException\r");
+        assertThat(arrayNode.get(0).textValue().trim()).isEqualTo("java.lang.RuntimeException");
         assertThat(arrayNode.get(1).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.testLogExceptionNullMessage");
     }
 }

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/EcsLayoutWithStackTraceAsArrayTest.java
@@ -50,7 +50,7 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         assertThat(log.get("error.stack_trace").isArray()).isTrue();
         ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
         assertThat(arrayNode.size()).isEqualTo(4);
-        assertThat(arrayNode.get(0).textValue().trim()).isEqualTo("java.lang.NumberFormatException: For input string: \"NOT_AN_INT\"");
+        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.NumberFormatException: For input string: \"NOT_AN_INT\"");
         assertThat(arrayNode.get(1).textValue()).startsWith("\t... suppressed");
         assertThat(arrayNode.get(2).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.numberFormatException");
         assertThat(arrayNode.get(3).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.testLogException");
@@ -75,7 +75,7 @@ public class EcsLayoutWithStackTraceAsArrayTest extends Log4j2EcsLayoutTest {
         assertThat(log.get("error.stack_trace").isArray()).isTrue();
         ArrayNode arrayNode = (ArrayNode) log.get("error.stack_trace");
         assertThat(arrayNode.size()).isEqualTo(4);
-        assertThat(arrayNode.get(0).textValue().trim()).isEqualTo("java.lang.RuntimeException");
+        assertThat(arrayNode.get(0).textValue()).isEqualTo("java.lang.RuntimeException");
         assertThat(arrayNode.get(1).textValue()).startsWith("\tat co.elastic.logging.log4j2.EcsLayoutWithStackTraceAsArrayTest.testLogExceptionNullMessage");
     }
 }

--- a/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
+++ b/log4j2-ecs-layout/src/test/java/co/elastic/logging/log4j2/Log4j2EcsLayoutTest.java
@@ -78,6 +78,7 @@ abstract class Log4j2EcsLayoutTest extends AbstractLog4j2EcsLayoutTest {
                 .setConfiguration(context.getConfiguration())
                 .setServiceName("test")
                 .setServiceVersion("test-version")
+                .setServiceEnvironment("test-environment")
                 .setServiceNodeName("test-node")
                 .setIncludeMarkers(true)
                 .setIncludeOrigin(true)

--- a/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
+++ b/log4j2-ecs-layout/src/test/resources/log4j2-test.xml
@@ -5,7 +5,7 @@
     </Properties>
     <Appenders>
         <List name="TestAppender">
-            <EcsLayout serviceName="test" serviceVersion="test-version" serviceNodeName="test-node" includeMarkers="true" includeOrigin="true"
+            <EcsLayout serviceName="test" serviceVersion="test-version" serviceEnvironment="test-environment" serviceNodeName="test-node" includeMarkers="true" includeOrigin="true"
                        eventDataset="testdataset" exceptionPattern="%ex{4}">
                 <KeyValuePair key="cluster.uuid" value="9fe9134b-20b0-465e-acf9-8cc09ac9053b"/>
                 <KeyValuePair key="node.id" value="${node.id}"/>

--- a/logback-ecs-encoder/src/main/java/co/elastic/logging/logback/EcsEncoder.java
+++ b/logback-ecs-encoder/src/main/java/co/elastic/logging/logback/EcsEncoder.java
@@ -47,6 +47,8 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
     private boolean stackTraceAsArray = false;
     private String serviceName;
     private String serviceVersion;
+
+    private String serviceEnvironment;
     private String serviceNodeName;
     private String eventDataset;
     private boolean includeMarkers = false;
@@ -109,6 +111,7 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
         serializeMarkers(event, builder);
         EcsJsonSerializer.serializeServiceName(builder, serviceName);
         EcsJsonSerializer.serializeServiceVersion(builder, serviceVersion);
+        EcsJsonSerializer.serializeServiceEnvironment(builder, serviceEnvironment);
         EcsJsonSerializer.serializeServiceNodeName(builder, serviceNodeName);
         EcsJsonSerializer.serializeEventDataset(builder, eventDataset);
         EcsJsonSerializer.serializeThreadName(builder, event.getThreadName());
@@ -175,6 +178,10 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
 
     public void setServiceVersion(String serviceVersion) {
         this.serviceVersion = serviceVersion;
+    }
+
+    public void setServiceEnvironment(String serviceEnvironment) {
+        this.serviceEnvironment = serviceEnvironment;
     }
 
     public void setServiceNodeName(String serviceNodeName) {

--- a/logback-ecs-encoder/src/main/java/co/elastic/logging/logback/EcsEncoder.java
+++ b/logback-ecs-encoder/src/main/java/co/elastic/logging/logback/EcsEncoder.java
@@ -47,7 +47,6 @@ public class EcsEncoder extends EncoderBase<ILoggingEvent> {
     private boolean stackTraceAsArray = false;
     private String serviceName;
     private String serviceVersion;
-
     private String serviceEnvironment;
     private String serviceNodeName;
     private String eventDataset;

--- a/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderTest.java
+++ b/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderTest.java
@@ -45,6 +45,7 @@ public class EcsEncoderTest extends AbstractEcsEncoderTest {
         EcsEncoder ecsEncoder = new EcsEncoder();
         ecsEncoder.setServiceName("test");
         ecsEncoder.setServiceVersion("test-version");
+        ecsEncoder.setServiceEnvironment("test-environment");
         ecsEncoder.setServiceNodeName("test-node");
         ecsEncoder.setIncludeMarkers(true);
         ecsEncoder.setIncludeOrigin(true);

--- a/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderWithStacktraceAsArrayTest.java
+++ b/logback-ecs-encoder/src/test/java/co/elastic/logging/logback/EcsEncoderWithStacktraceAsArrayTest.java
@@ -48,6 +48,7 @@ public class EcsEncoderWithStacktraceAsArrayTest extends AbstractEcsEncoderTest 
         EcsEncoder ecsEncoder = new EcsEncoder();
         ecsEncoder.setServiceName("test");
         ecsEncoder.setServiceVersion("test-version");
+        ecsEncoder.setServiceEnvironment("test-environment");
         ecsEncoder.setIncludeMarkers(true);
         ecsEncoder.setIncludeOrigin(true);
         ecsEncoder.addAdditionalField(new AdditionalField("key1", "value1"));

--- a/logback-ecs-encoder/src/test/resources/logback-config-with-nop-throwable-converter.xml
+++ b/logback-ecs-encoder/src/test/resources/logback-config-with-nop-throwable-converter.xml
@@ -5,6 +5,7 @@
             <throwableConverter class="ch.qos.logback.classic.pattern.NopThrowableInformationConverter"/>
             <serviceName>test</serviceName>
             <serviceVersion>test-version</serviceVersion>
+            <serviceEnvironment>test-environment</serviceEnvironment>
             <serviceNodeName>test-node</serviceNodeName>
             <includeMarkers>true</includeMarkers>
             <includeOrigin>true</includeOrigin>

--- a/logback-ecs-encoder/src/test/resources/logback-config.xml
+++ b/logback-ecs-encoder/src/test/resources/logback-config.xml
@@ -4,6 +4,7 @@
         <encoder class="co.elastic.logging.logback.EcsEncoder">
             <serviceName>test</serviceName>
             <serviceVersion>test-version</serviceVersion>
+            <serviceEnvironment>test-environment</serviceEnvironment>
             <serviceNodeName>test-node</serviceNodeName>
             <includeMarkers>true</includeMarkers>
             <includeOrigin>true</includeOrigin>


### PR DESCRIPTION
As an extension of #168 
We are hosting different environments of our applications, i.e. dev, test and of course prod.
In order to distinguish logs, we set the service.environment field. With this change it is easier to achieve.
Please review and feel free to merge.