### PR TITLE
synchronize ecs-logging spec

### DIFF
--- a/ecs-logging-core/src/test/resources/spec/spec.json
+++ b/ecs-logging-core/src/test/resources/spec/spec.json
@@ -85,6 +85,15 @@
                 "When an APM agent is active and `service_node_name` is manually configured, the agent should auto-configure this field if not already set."
             ]
         },
+        "service.version": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-version",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure it if not already set."
+            ]
+        },
         "event.dataset": {
             "type": "string",
             "required": false,
@@ -100,6 +109,15 @@
                 "Otherwise, agents should also set `event.dataset=${service.name}`",
                 "",
                 "The field helps to filter for different log streams from the same pod, for example and is required for log anomaly detection."
+            ]
+        },
+        "service.environment": {
+            "type": "string",
+            "required": false,
+            "url": "https://www.elastic.co/guide/en/ecs/current/ecs-service.html#field-service-environment",
+            "comment": [
+                "Configurable by users.",
+                "When an APM agent is active, it should auto-configure it if not already set."
             ]
         },
         "process.thread.name": {


### PR DESCRIPTION
### What

ECS logging specs automatic sync

### Why

*Changeset*
* https://github.com/elastic/ecs-logging/commit/d3ffcf1 Adding service.environment to the spec (https://github.com/elastic/ecs-logging/pull/62)