### PR TITLE
ci: release automation

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+##  This script reverts the Vault context for the release and snapshot pipelines.
+##
+##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET for those values that contain
+##        any sensitive data. Buildkite can mask those values automatically
+
+set -euo pipefail
+
+VAULT_TOKEN=$VAULT_TOKEN_PREVIOUS
+export VAULT_TOKEN

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 ##  This script reverts the Vault context for the release and snapshot pipelines.
 ##
-##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
-##        surprises please use the suffix _SECRET for those values that contain
+##  NOTE: *_SECRET or *_TOKEN env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET or _TOKEN for those values that contain
 ##        any sensitive data. Buildkite can mask those values automatically
 
 set -euo pipefail
 
-VAULT_TOKEN=$VAULT_TOKEN_PREVIOUS
+VAULT_TOKEN=$PREVIOUS_VAULT_TOKEN
 export VAULT_TOKEN

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -54,10 +54,10 @@ echo "--- Configure git context"
 git config --global user.email "infra-root+apmmachine@elastic.co"
 git config --global user.name "apmmachine"
 
-echo "--- Install JDK11"
+echo "--- Install JDK17"
 JAVA_URL=https://jvm-catalog.elastic.co/jdk
-JAVA_HOME=$(pwd)/.openjdk11
-JAVA_PKG="$JAVA_URL/latest_openjdk_11_linux.tar.gz"
+JAVA_HOME=$(pwd)/.openjdk17
+JAVA_PKG="$JAVA_URL/latest_openjdk_17_linux.tar.gz"
 curl -L --output /tmp/jdk.tar.gz "$JAVA_PKG"
 mkdir -p "$JAVA_HOME"
 tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+##  This script prepares the Vault context for the release and snapshot pipelines.
+##
+##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET for those values that contain
+##        any sensitive data. Buildkite can mask those values automatically
+
+set -eo pipefail
+
+echo "--- Prepare vault context"
+VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
+export VAULT_ROLE_ID_SECRET
+
+VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
+export VAULT_SECRET_ID_SECRET
+
+VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-ecs-logging-java/internal-ci-approle)
+export VAULT_ADDR
+
+# Delete the vault specific accessing the ci vault
+PREVIOUS_VAULT_TOKEN=$VAULT_TOKEN
+export PREVIOUS_VAULT_TOKEN
+unset VAULT_TOKEN
+
+echo "--- Prepare keys context"
+VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
+export VAULT_TOKEN
+
+# Signing keys
+vault read -field=key secret/release/signing >$KEY_FILE
+KEYPASS_SECRET=$(vault read -field=passphrase secret/release/signing)
+export KEYPASS_SECRET
+export KEY_ID_SECRET=D88E42B4
+
+# Prepare a secure temp folder not shared between other jobs to store the key ring
+export TMP_WORKSPACE=/tmp/secured
+export KEY_FILE=$TMP_WORKSPACE"/private.key"
+# Secure home for our keyring
+export GNUPGHOME=$TMP_WORKSPACE"/keyring"
+mkdir -p $GNUPGHOME
+chmod -R 700 $TMP_WORKSPACE
+
+# Import the key into the keyring
+echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"
+
+# Export secring
+export SECRING_FILE=$GNUPGHOME"/secring.gpg"
+gpg --pinentry-mode=loopback --passphrase "$KEYPASS_SECRET" --export-secret-key $KEY_ID_SECRET > "$SECRING_FILE"
+
+echo "--- Configure git context"
+# Configure the committer since the maven release requires to push changes to GitHub
+# This will help with the SLSA requirements.
+git config --global user.email "infra-root+apmmachine@elastic.co"
+git config --global user.name "apmmachine"
+
+echo "--- Install JDK11"
+JAVA_URL=https://jvm-catalog.elastic.co/jdk
+JAVA_HOME=$(pwd)/.openjdk11
+JAVA_PKG="$JAVA_URL/latest_openjdk_11_linux.tar.gz"
+curl -L --output /tmp/jdk.tar.gz "$JAVA_PKG"
+mkdir -p "$JAVA_HOME"
+tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+
+export JAVA_HOME
+export PATH=$JAVA_HOME/bin:$PATH
+

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-##  This script prepares the Vault context for the release and snapshot pipelines.
+##  This script prepares the Vault context and required tooling
+##  for the release and snapshot pipelines.
 ##
-##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
-##        surprises please use the suffix _SECRET for those values that contain
+##  NOTE: *_SECRET or *_TOKEN env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET or _TOKEN for those values that contain
 ##        any sensitive data. Buildkite can mask those values automatically
 
 set -eo pipefail

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -1,0 +1,13 @@
+agents:
+  provider: "gcp"
+
+steps:
+  - label: "Run the release"
+    key: "release"
+    commands: .ci/release.sh | tee release.out
+    artifact_paths: "release.out"
+
+notify:
+  - slack:
+      channels:
+        - "#apm-agent-java"

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -1,0 +1,15 @@
+agents:
+  provider: "gcp"
+
+steps:
+  - label: "Run the snapshot"
+    key: "release"
+    commands: .ci/snapshot.sh | tee snapshot.out
+    artifact_paths:
+      - "snapshot.out"
+      - "**/target/*"
+
+notify:
+  - slack:
+      channels:
+        - "#apm-agent-java"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+## This script runs the release given the different environment variables
+##  branch_specifier
+##  dry_run
+##
+##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET for those values that contain
+##        any sensitive data. Buildkite can mask those values automatically
+
+set -e
+
+echo "--- Prepare vault context"
+set +x
+VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
+export VAULT_ROLE_ID_SECRET
+VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
+export VAULT_SECRET_ID_SECRET
+VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-agent-android/internal-ci-approle)
+export VAULT_ADDR
+
+# Delete the vault specific accessing the ci vault
+export VAULT_TOKEN_PREVIOUS=$VAULT_TOKEN
+unset VAULT_TOKEN
+
+echo "--- Prepare release context"
+# Avoid detached HEAD since the release plugin requires to be on a branch
+git checkout -f "${branch_specifier}"
+# Prepare a secure temp folder not shared between other jobs to store the key ring
+export TMP_WORKSPACE=/tmp/secured
+export KEY_FILE=$TMP_WORKSPACE"/private.key"
+# Secure home for our keyring
+export GNUPGHOME=$TMP_WORKSPACE"/keyring"
+mkdir -p $GNUPGHOME
+chmod -R 700 $TMP_WORKSPACE
+# Make sure we delete this folder before leaving even in case of failure
+clean_up () {
+  ARG=$?
+  export VAULT_TOKEN=$VAULT_TOKEN_PREVIOUS
+  echo "--- Deleting tmp workspace"
+  rm -rf $TMP_WORKSPACE
+  exit $ARG
+}
+trap clean_up EXIT
+
+echo "--- Prepare keys context"
+set +x
+VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
+export VAULT_TOKEN
+# Nexus credentials (they cannot use the _SECRET pattern since they are in-memory based)
+# See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+ORG_GRADLE_PROJECT_sonatypeUsername=$(vault read -field=username secret/release/nexus)
+export ORG_GRADLE_PROJECT_sonatypeUsername
+ORG_GRADLE_PROJECT_sonatypePassword=$(vault read -field=password secret/release/nexus)
+export ORG_GRADLE_PROJECT_sonatypePassword
+
+# Gradle Plugin portal credentials
+PLUGIN_PORTAL_KEY=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.key)
+export PLUGIN_PORTAL_KEY
+PLUGIN_PORTAL_SECRET=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.secret)
+export PLUGIN_PORTAL_SECRET
+
+# Signing keys
+vault read -field=key secret/release/signing >$KEY_FILE
+KEYPASS_SECRET=$(vault read -field=passphrase secret/release/signing)
+export KEYPASS_SECRET
+export KEY_ID_SECRET=D88E42B4
+unset VAULT_TOKEN
+
+# Import the key into the keyring
+echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"
+
+# Export secring
+export SECRING_FILE=$GNUPGHOME"/secring.gpg"
+gpg --pinentry-mode=loopback --passphrase "$KEYPASS_SECRET" --export-secret-key $KEY_ID_SECRET > "$SECRING_FILE"
+set -x
+# Configure the committer since the maven release requires to push changes to GitHub
+# This will help with the SLSA requirements.
+git config --global user.email "infra-root+apmmachine@elastic.co"
+git config --global user.name "apmmachine"
+
+echo "--- Install JDK11"
+JAVA_URL=https://jvm-catalog.elastic.co/jdk
+JAVA_HOME=$(pwd)/.openjdk11
+JAVA_PKG="$JAVA_URL/latest_openjdk_11_linux.tar.gz"
+curl -L --output /tmp/jdk.tar.gz "$JAVA_PKG"; \
+  mkdir -p "$JAVA_HOME"; \
+  tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+export JAVA_HOME
+export PATH=$JAVA_HOME/bin:$PATH
+
+set +x
+echo "--- Release the binaries to Maven Central"
+if [[ "$dry_run" == "true" ]] ; then
+  echo './mvnw release:prepare release:perform --settings .ci/settings.xml --batch-mode'
+else
+  # providing settings in arguments to make sure they are propagated to the forked maven release process
+  ./mvnw release:prepare release:perform --settings .ci/settings.xml -Darguments="--settings .ci/settings.xml" --batch-mode
+fi

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## This script runs the release given the different environment variables
+##  This script runs the release given the different environment variables
 ##  branch_specifier
 ##  dry_run
 ##
@@ -11,11 +11,11 @@ set -e
 
 echo "--- Prepare vault context"
 set +x
-VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
+VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
 export VAULT_ROLE_ID_SECRET
-VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
+VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
 export VAULT_SECRET_ID_SECRET
-VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-agent-android/internal-ci-approle)
+VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-ecs-logging-java/internal-ci-approle)
 export VAULT_ADDR
 
 # Delete the vault specific accessing the ci vault
@@ -46,18 +46,6 @@ echo "--- Prepare keys context"
 set +x
 VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
 export VAULT_TOKEN
-# Nexus credentials (they cannot use the _SECRET pattern since they are in-memory based)
-# See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
-ORG_GRADLE_PROJECT_sonatypeUsername=$(vault read -field=username secret/release/nexus)
-export ORG_GRADLE_PROJECT_sonatypeUsername
-ORG_GRADLE_PROJECT_sonatypePassword=$(vault read -field=password secret/release/nexus)
-export ORG_GRADLE_PROJECT_sonatypePassword
-
-# Gradle Plugin portal credentials
-PLUGIN_PORTAL_KEY=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.key)
-export PLUGIN_PORTAL_KEY
-PLUGIN_PORTAL_SECRET=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.secret)
-export PLUGIN_PORTAL_SECRET
 
 # Signing keys
 vault read -field=key secret/release/signing >$KEY_FILE

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,80 +1,25 @@
 #!/usr/bin/env bash
 ##  This script runs the release given the different environment variables
-##  branch_specifier
-##  dry_run
+##    branch_specifier
+##    dry_run
 ##
-##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
-##        surprises please use the suffix _SECRET for those values that contain
-##        any sensitive data. Buildkite can mask those values automatically
+##  It relies on the .buildkite/hooks/pre-command so the Vault is prepared
+##  automatically by buildkite.
 
 set -e
 
-echo "--- Prepare vault context"
-set +x
-VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_ROLE_ID_SECRET
-VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_SECRET_ID_SECRET
-VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_ADDR
-
-# Delete the vault specific accessing the ci vault
-export VAULT_TOKEN_PREVIOUS=$VAULT_TOKEN
-unset VAULT_TOKEN
-
-echo "--- Prepare release context"
-# Avoid detached HEAD since the release plugin requires to be on a branch
-git checkout -f "${branch_specifier}"
-# Prepare a secure temp folder not shared between other jobs to store the key ring
-export TMP_WORKSPACE=/tmp/secured
-export KEY_FILE=$TMP_WORKSPACE"/private.key"
-# Secure home for our keyring
-export GNUPGHOME=$TMP_WORKSPACE"/keyring"
-mkdir -p $GNUPGHOME
-chmod -R 700 $TMP_WORKSPACE
 # Make sure we delete this folder before leaving even in case of failure
 clean_up () {
   ARG=$?
-  export VAULT_TOKEN=$VAULT_TOKEN_PREVIOUS
+  export VAULT_TOKEN=$PREVIOUS_VAULT_TOKEN
   echo "--- Deleting tmp workspace"
   rm -rf $TMP_WORKSPACE
   exit $ARG
 }
 trap clean_up EXIT
 
-echo "--- Prepare keys context"
-set +x
-VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
-export VAULT_TOKEN
-
-# Signing keys
-vault read -field=key secret/release/signing >$KEY_FILE
-KEYPASS_SECRET=$(vault read -field=passphrase secret/release/signing)
-export KEYPASS_SECRET
-export KEY_ID_SECRET=D88E42B4
-unset VAULT_TOKEN
-
-# Import the key into the keyring
-echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"
-
-# Export secring
-export SECRING_FILE=$GNUPGHOME"/secring.gpg"
-gpg --pinentry-mode=loopback --passphrase "$KEYPASS_SECRET" --export-secret-key $KEY_ID_SECRET > "$SECRING_FILE"
-set -x
-# Configure the committer since the maven release requires to push changes to GitHub
-# This will help with the SLSA requirements.
-git config --global user.email "infra-root+apmmachine@elastic.co"
-git config --global user.name "apmmachine"
-
-echo "--- Install JDK11"
-JAVA_URL=https://jvm-catalog.elastic.co/jdk
-JAVA_HOME=$(pwd)/.openjdk11
-JAVA_PKG="$JAVA_URL/latest_openjdk_11_linux.tar.gz"
-curl -L --output /tmp/jdk.tar.gz "$JAVA_PKG"; \
-  mkdir -p "$JAVA_HOME"; \
-  tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
-export JAVA_HOME
-export PATH=$JAVA_HOME/bin:$PATH
+# Avoid detached HEAD since the release plugin requires to be on a branch
+git checkout -f "${branch_specifier}"
 
 set +x
 echo "--- Release the binaries to Maven Central"

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+##  This script runs the snapshot
+##
+##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET for those values that contain
+##        any sensitive data. Buildkite can mask those values automatically
+
+set -e
+
+echo "--- Prepare vault context"
+set +x
+VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
+export VAULT_ROLE_ID_SECRET
+VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
+export VAULT_SECRET_ID_SECRET
+VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-agent-android/internal-ci-approle)
+export VAULT_ADDR
+
+# Delete the vault specific accessing the ci vault
+export VAULT_TOKEN_PREVIOUS=$VAULT_TOKEN
+unset VAULT_TOKEN
+
+echo "--- Prepare release context"
+# Prepare a secure temp folder not shared between other jobs to store the key ring
+export TMP_WORKSPACE=/tmp/secured
+export KEY_FILE=$TMP_WORKSPACE"/private.key"
+# Secure home for our keyring
+export GNUPGHOME=$TMP_WORKSPACE"/keyring"
+mkdir -p $GNUPGHOME
+chmod -R 700 $TMP_WORKSPACE
+# Make sure we delete this folder before leaving even in case of failure
+clean_up () {
+  ARG=$?
+  export VAULT_TOKEN=$VAULT_TOKEN_PREVIOUS
+  echo "--- Deleting tmp workspace"
+  rm -rf $TMP_WORKSPACE
+  exit $ARG
+}
+trap clean_up EXIT
+
+echo "--- Prepare keys context"
+set +x
+VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
+export VAULT_TOKEN
+
+# Signing keys
+vault read -field=key secret/release/signing >$KEY_FILE
+KEYPASS_SECRET=$(vault read -field=passphrase secret/release/signing)
+export KEYPASS_SECRET
+export KEY_ID_SECRET=D88E42B4
+unset VAULT_TOKEN
+
+# Import the key into the keyring
+echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"
+
+# Export secring
+export SECRING_FILE=$GNUPGHOME"/secring.gpg"
+gpg --pinentry-mode=loopback --passphrase "$KEYPASS_SECRET" --export-secret-key $KEY_ID_SECRET > "$SECRING_FILE"
+set -x
+# Configure the committer since the maven release requires to push changes to GitHub
+# This will help with the SLSA requirements.
+git config --global user.email "infra-root+apmmachine@elastic.co"
+git config --global user.name "apmmachine"
+
+echo "--- Install JDK11"
+JAVA_URL=https://jvm-catalog.elastic.co/jdk
+JAVA_HOME=$(pwd)/.openjdk11
+JAVA_PKG="$JAVA_URL/latest_openjdk_11_linux.tar.gz"
+curl -L --output /tmp/jdk.tar.gz "$JAVA_PKG"; \
+  mkdir -p "$JAVA_HOME"; \
+  tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+export JAVA_HOME
+export PATH=$JAVA_HOME/bin:$PATH
+
+set +x
+echo "--- Deploy the snapshot"
+./mvnw -s .ci/settings.xml -Pgpg clean deploy --batch-mode

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-##  This script runs the snapshot
+##  This script runs the snapshot given the different environment variables
+##    dry_run
 ##
-##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
-##        surprises please use the suffix _SECRET for those values that contain
-##        any sensitive data. Buildkite can mask those values automatically
+##  It relies on the .buildkite/hooks/pre-command so the Vault and other tooling
+##  are prepared automatically by buildkite.
+##
 
 set -e
 
@@ -19,4 +20,8 @@ trap clean_up EXIT
 
 set +x
 echo "--- Deploy the snapshot"
-./mvnw -s .ci/settings.xml -Pgpg clean deploy --batch-mode
+if [[ "$dry_run" == "true" ]] ; then
+  echo './mvnw -s .ci/settings.xml -Pgpg clean deploy --batch-mode'
+else
+  ./mvnw -s .ci/settings.xml -Pgpg clean deploy --batch-mode
+fi

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -9,11 +9,11 @@ set -e
 
 echo "--- Prepare vault context"
 set +x
-VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
+VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
 export VAULT_ROLE_ID_SECRET
-VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
+VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
 export VAULT_SECRET_ID_SECRET
-VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-agent-android/internal-ci-approle)
+VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-ecs-logging-java/internal-ci-approle)
 export VAULT_ADDR
 
 # Delete the vault specific accessing the ci vault

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -7,70 +7,15 @@
 
 set -e
 
-echo "--- Prepare vault context"
-set +x
-VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_ROLE_ID_SECRET
-VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_SECRET_ID_SECRET
-VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_ADDR
-
-# Delete the vault specific accessing the ci vault
-export VAULT_TOKEN_PREVIOUS=$VAULT_TOKEN
-unset VAULT_TOKEN
-
-echo "--- Prepare release context"
-# Prepare a secure temp folder not shared between other jobs to store the key ring
-export TMP_WORKSPACE=/tmp/secured
-export KEY_FILE=$TMP_WORKSPACE"/private.key"
-# Secure home for our keyring
-export GNUPGHOME=$TMP_WORKSPACE"/keyring"
-mkdir -p $GNUPGHOME
-chmod -R 700 $TMP_WORKSPACE
 # Make sure we delete this folder before leaving even in case of failure
 clean_up () {
   ARG=$?
-  export VAULT_TOKEN=$VAULT_TOKEN_PREVIOUS
+  export VAULT_TOKEN=$PREVIOUS_VAULT_TOKEN
   echo "--- Deleting tmp workspace"
   rm -rf $TMP_WORKSPACE
   exit $ARG
 }
 trap clean_up EXIT
-
-echo "--- Prepare keys context"
-set +x
-VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
-export VAULT_TOKEN
-
-# Signing keys
-vault read -field=key secret/release/signing >$KEY_FILE
-KEYPASS_SECRET=$(vault read -field=passphrase secret/release/signing)
-export KEYPASS_SECRET
-export KEY_ID_SECRET=D88E42B4
-unset VAULT_TOKEN
-
-# Import the key into the keyring
-echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"
-
-# Export secring
-export SECRING_FILE=$GNUPGHOME"/secring.gpg"
-gpg --pinentry-mode=loopback --passphrase "$KEYPASS_SECRET" --export-secret-key $KEY_ID_SECRET > "$SECRING_FILE"
-set -x
-# Configure the committer since the maven release requires to push changes to GitHub
-# This will help with the SLSA requirements.
-git config --global user.email "infra-root+apmmachine@elastic.co"
-git config --global user.name "apmmachine"
-
-echo "--- Install JDK11"
-JAVA_URL=https://jvm-catalog.elastic.co/jdk
-JAVA_HOME=$(pwd)/.openjdk11
-JAVA_PKG="$JAVA_URL/latest_openjdk_11_linux.tar.gz"
-curl -L --output /tmp/jdk.tar.gz "$JAVA_PKG"; \
-  mkdir -p "$JAVA_HOME"; \
-  tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
-export JAVA_HOME
-export PATH=$JAVA_HOME/bin:$PATH
 
 set +x
 echo "--- Deploy the snapshot"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+---
+name: release
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_specifier:
+        description: The branch to release ex. main or 0.6.
+        required: true
+        default: "main"
+        type: string
+
+      dry_run:
+        description: If set, this will not run a release but run a dry-run
+        default: false
+        type: boolean
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: buildkite
+        name: Run Release
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ecs-logging-java-release
+          waitFor: false
+          printBuildLogs: false
+          buildEnvVars: |
+            branch_specifier=${{ inputs.branch_specifier || 'main' }}
+            dry_run=${{ inputs.dry_run || 'false' }}
+
+      - if: ${{ success() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: "#apm-agent-mobile"
+          message: |
+            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite.outputs.build }}|build>)
+
+      - if: ${{ failure() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: "#apm-agent-mobile"
+          message: |
+            :ghost: [${{ github.repository }}] Release *${{ github.ref_name }}* didn't get triggered in Buildkite.
+            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-mobile"
+          channel: "#apm-agent-java"
           message: |
             :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite.outputs.build }}|build>)
 
@@ -54,7 +54,7 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-mobile"
+          channel: "#apm-agent-java"
           message: |
             :ghost: [${{ github.repository }}] Release *${{ github.ref_name }}* didn't get triggered in Buildkite.
             Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
       dry_run:
-        description: If set, this will not run a release but run a dry-run
+        description: If set, run a dry-run release
         default: false
         type: boolean
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: If set, run a dry-run snapshot
+        default: false
+        type: boolean
 
 jobs:
   deploy:
@@ -22,6 +28,8 @@ jobs:
           pipeline: ecs-logging-java-snapshot
           waitFor: false
           printBuildLogs: false
+          buildEnvVars: |
+            dry_run=${{ inputs.dry_run || 'false' }}
 
       - if: ${{ failure() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,35 @@
+---
+name: snapshot
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: buildkite
+        name: Run Deploy
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ecs-logging-java-snapshot
+          waitFor: false
+          printBuildLogs: false
+
+      - if: ${{ failure() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: "#apm-agent-java"
+          message: |
+            :ghost: [${{ github.repository }}] Snapshot *${{ github.ref_name }}* didn't get triggered in Buildkite.
+            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to the ECS-based logging for Java applications
+
+The APM Agent is open source and we love to receive contributions from our community — you!
+
+There are many ways to contribute, from writing tutorials or blog posts, improving the
+documentation, submitting bug reports and feature requests or writing code.
+
+If you want to be rewarded for your contributions, sign up for
+the [Elastic Contributor Program](https://www.elastic.co/community/contributor). Each time you make
+a valid contribution, you’ll earn points that increase your chances of winning prizes and being
+recognized as a top contributor.
+
+You can get in touch with us through [Discuss](https://discuss.elastic.co/c/apm), feedback and ideas
+are always welcome.
+
+## Code contributions
+
+If you have a bugfix or new feature that you would like to contribute, please find or open an issue
+about it first. Talk about what you would like to do. It may be that somebody is already working on
+it, or that there are particular issues that you should know about before implementing the change.
+
+### Submitting your changes
+
+Generally, we require that you test any code you are adding or modifying. Once your changes are
+ready to submit for review:
+
+1. Sign the Contributor License Agreement
+
+   Please make sure you have signed
+   our [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). We are not
+   asking you to assign copyright to us, but to give us the right to distribute your code without
+   restriction. We ask this of all contributors in order to assure our users of the origin and
+   continuing existence of the code. You only need to sign the CLA once.
+
+2. Test your changes
+
+   Run the test suite to make sure that nothing is broken. See [testing](#testing) for details.
+
+3. Rebase your changes
+
+   Update your local repository with the most recent code from the main repo, and rebase your branch
+   on top of the latest master branch. We prefer your initial changes to be squashed into a single
+   commit. Later, if we ask you to make changes, add them as separate commits. This makes them
+   easier to review. As a final step before merging we will either ask you to squash all commits
+   yourself or we'll do it for you.
+
+4. Submit a pull request
+
+   Push your local changes to your forked copy of the repository
+   and [submit a pull request](https://help.github.com/articles/using-pull-requests). In the pull
+   request, choose a title which sums up the changes that you have made, and in the body provide
+   more details about what your changes do. Also mention the number of the issue where discussion
+   has taken place, eg "Closes #123".
+
+5. Be patient
+
+   We might not be able to review your code as fast as we would like to, but we'll do our best to
+   dedicate it the attention it deserves. Your effort is much appreciated!
+
+### Workflow
+
+All feature development and most bug fixes hit the master branch first. Pull requests should be
+reviewed by someone with commit access. Once approved, the author of the pull request, or reviewer
+if the author does not have commit access, should "Squash and merge".
+
+### Testing
+
+You can run the following command to run all the unit tests available:
+
+```bash
+./mvnw test
+```
+
+### Releasing
+
+The release steps have been defined in `.ci/release.sh` which it gets triggered within the BuildKite context.
+
+Releases are triggered manually using GitHub actions, and the GitHub action is the one contacting BuildKite.
+To run a release then
+* Navigate to the [GitHub job](https://github.com/elastic/ecs-logging-java/actions/workflows/release.yml)
+* Choose Run workflow.
+* Fill the form and click `Run workflow` and wait for a few minutes to complete
+
+And email/slack message will be sent with the outcome.
+
+#### Further details
+
+* There are specific vault secrets accessible only in `secret/ci/elastic-ecs-logging-java`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-java%2Fecs-logging-java-mbp%2Fmain)](https://apm-ci.elastic.co/job/apm-agent-java/job/ecs-logging-java-mbp/job/main/)
+[![Build Status](https://github.com/elastic/ecs-logging-java/actions/workflows/test.yml/badge.svg)](https://github.com/elastic/ecs-logging-java/actions/workflows/test.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/co.elastic.logging/ecs-logging-java-parent.svg)](https://search.maven.org/search?q=g:co.elastic.logging)
 
 # ECS-based logging for Java applications


### PR DESCRIPTION
### What

Use Buildkite to run the releases interacting with Maven central.

### Why

Jenkins is deprecated hence we use Buildkite for releases, while we use GitHub actions for the CI.

Buildkite will act as a provisioner, pretty much:
- Request a GCP VM
- Access vault
- Run the `release.sh` or `snapshot.sh` scripts
- Notify the result in Slack.

As a consequence, this project will contain all the moving pieces for the release, including the scripts needed for the releases/snapshots.

### Use cases

1) Releases will be triggered manually, using the GitHub actions UI.
2) Snapshots will happen on merge commits automatically and also supported with manually trigger using the GH actions UI

### Tasks

- [x] Create jobs in Buildkite
- [x] Create vault secrets
- [x] Mask passwords/secrets using the Buildkite hooks. 
- [ ] Agree with the @elastic/apm-agent-java team so they are aware of this particular automation.