### PR TITLE
action: update specs

### DIFF
--- a/.ci/update-specs.yml
+++ b/.ci/update-specs.yml
@@ -1,0 +1,57 @@
+---
+name: update specs
+
+scms:
+  githubConfig:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: ecs-logging-java
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+
+actions:
+  ecs-logging-java:
+    kind: github/pullrequest
+    scmid: githubConfig
+    sourceid: sha
+    spec:
+      automerge: false
+      labels:
+        - dependencies
+      title: 'synchronize ecs-logging spec'
+      description: |-
+        ### What
+
+        ECS logging specs automatic sync
+
+        ### Why
+
+        *Changeset*
+        * https://github.com/elastic/ecs-logging/commit/{{ source "sha" }}
+
+sources:
+  spec.json:
+    name: Get specs from json
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/ecs-logging/main/spec/spec.json
+
+  sha:
+    name: Get commit
+    kind: json
+    spec:
+      file: 'https://api.github.com/repos/elastic/ecs-logging/commits?path=spec%2Fspec.json&page=1&per_page=1'
+      key: ".[0].sha"
+
+targets:
+  spec.json-update:
+    name: 'synchronize ecs-logging spec'
+    kind: file
+    sourceid: spec.json
+    scmid: githubConfig
+    spec:
+      file: ecs-logging-core/src/test/resources/spec/spec.json

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -6,6 +6,7 @@ on:
     workflows:
       - test
       - test-reporter
+      - update-specs
     types: [completed]
 
 jobs:

--- a/.github/workflows/update-specs.yml
+++ b/.github/workflows/update-specs.yml
@@ -1,0 +1,30 @@
+---
+# Send PRs to the subscribed ECS Agents if the spec files (JSON) are modified
+name: update-specs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Setup Git
+        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
+
+      - name: Run Updatecli
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: updatecli apply --config ./.ci/update-specs.yml


### PR DESCRIPTION
### What

Use GitHub actions in addition to the [`updatecli`](https://www.updatecli.io/) to bump the json schemas created in `ecs-logging`.

It runs on a daily basis and create a Pull Request if new changes exist.

Create PRs with the description pointing to the original change in the `ecs-logging`, similarly done in https://github.com/elastic/ecs-logging-java/pull/196

### Why

Jenkins ecosystem at Elastic is deprecated, so let's use GH actions with `updatecli`, so consumers can control what to do and when.

### Test

https://github.com/elastic/ecs-logging-java/pull/198 has been created based on these changes.

### Further details

The automation relied on Jenkins and projects were onboarded by having a configuration entry in  https://github.com/elastic/ecs-logging/blob/main/.ci/.jenkins-loggers.yml 