### PR TITLE
action: use elastic/apm-pipeline-library/.github/actions/updatecli

### DIFF
--- a/.github/workflows/update-specs.yml
+++ b/.github/workflows/update-specs.yml
@@ -8,8 +8,7 @@ on:
     - cron: '0 6 * * *'
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   bump:
@@ -18,13 +17,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Setup Git
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
-
-      - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
-
-      - name: Run Updatecli
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: updatecli apply --config ./.ci/update-specs.yml
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@feature/use-github-action-composite-updatecli
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/update-specs.yml


### PR DESCRIPTION
### What

Use GitHub composite action

### Why

Reuse code and solve the existing issue with Workflows wont' be enabled for PRs created on behalf of `GitHUb actions [bot]`, see https://github.com/elastic/ecs-logging-java/pull/200