### PR TITLE
release: remove local repository pointing to Jenkins and tweak errors propagation in the buildkite pipelines

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -4,8 +4,8 @@ agents:
 steps:
   - label: "Run the release"
     key: "release"
-    commands: .ci/release.sh | tee release.out
-    artifact_paths: "release.out"
+    commands: .ci/release.sh
+    artifact_paths: "release.txt"
 
 notify:
   - slack:

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -4,9 +4,9 @@ agents:
 steps:
   - label: "Run the snapshot"
     key: "release"
-    commands: .ci/snapshot.sh | tee snapshot.out
+    commands: .ci/snapshot.sh
     artifact_paths:
-      - "snapshot.out"
+      - "snapshot.txt"
       - "**/target/*"
 
 notify:

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -11,5 +11,6 @@ steps:
 
 notify:
   - slack:
+    if: build.state == "failed"
       channels:
         - "#apm-agent-java"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -3,10 +3,10 @@
 ##    branch_specifier
 ##    dry_run
 ##
-##  It relies on the .buildkite/hooks/pre-command so the Vault is prepared
-##  automatically by buildkite.
-
-set -e
+##  It relies on the .buildkite/hooks/pre-command so the Vault and other tooling
+##  are prepared automatically by buildkite.
+##
+set -eo pipefail
 
 # Make sure we delete this folder before leaving even in case of failure
 clean_up () {
@@ -27,5 +27,5 @@ if [[ "$dry_run" == "true" ]] ; then
   echo './mvnw release:prepare release:perform --settings .ci/settings.xml --batch-mode'
 else
   # providing settings in arguments to make sure they are propagated to the forked maven release process
-  ./mvnw release:prepare release:perform --settings .ci/settings.xml -Darguments="--settings .ci/settings.xml" --batch-mode
+  ./mvnw release:prepare release:perform --settings .ci/settings.xml -Darguments="--settings .ci/settings.xml" --batch-mode | tee release.txt
 fi

--- a/.ci/settings.xml
+++ b/.ci/settings.xml
@@ -1,6 +1,5 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
-    <localRepository>/var/lib/jenkins/.m2/repository</localRepository>
     <pluginGroups>
         <pluginGroup>org.apache.maven.plugins</pluginGroup>
         <pluginGroup>org.codehaus.mojo</pluginGroup>

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -6,7 +6,7 @@
 ##  are prepared automatically by buildkite.
 ##
 
-set -e
+set -eo pipefail
 
 # Make sure we delete this folder before leaving even in case of failure
 clean_up () {
@@ -23,5 +23,5 @@ echo "--- Deploy the snapshot"
 if [[ "$dry_run" == "true" ]] ; then
   echo './mvnw -s .ci/settings.xml -Pgpg clean deploy --batch-mode'
 else
-  ./mvnw -s .ci/settings.xml -Pgpg clean deploy --batch-mode
+  ./mvnw -s .ci/settings.xml -Pgpg clean deploy --batch-mode | tee snapshot.txt
 fi


### PR DESCRIPTION
### What

After running a `snapshot` release it didn't fail but shown the below stacktrace

```


Deploy the snapshot | 3s
-- | --
  | [ERROR] Could not create local repository at /var/lib/jenkins/.m2/repository -> [Help 1]
  | [ERROR]
  | [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
  | [ERROR] Re-run Maven using the -X switch to enable full debug logging.
  | [ERROR]
  | [ERROR] For more information about the errors and possible solutions, please read the following articles:
  | [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/LocalRepositoryNotAccessibleException
  | Deleting tmp workspace | 0s
  | Running local post-command hook | 0s
  | Uploading artifacts


```

This PR fixes the above by:
- reporting errors if a bash pipe failed when using the `tee`
- reporting slack messages only if a snapshot failed
- fix the underneath issue by using the local repository pointing to Jenkins