### PR TITLE
buildkite: fix slack notification

### DIFF
--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -10,7 +10,5 @@ steps:
       - "**/target/*"
 
 notify:
-  - slack:
-    if: build.state == "failed"
-      channels:
-        - "#apm-agent-java"
+  - slack: "#apm-agent-java"
+    if: 'build.state != "passed"'


### PR DESCRIPTION
Fixes

```
2023-02-15 12:39:54 FATAL  Pipeline parsing of "snapshot.yml" failed (Failed to parse snapshot.yml: line 15: mapping values are not allowed in this context)
--
  | 🚨 Error: The command exited with status 1
```

It seems the syntax might be different when using conditionals, though I cannot find any reasons in the [docs](https://buildkite.com/docs/pipelines/notifications#slack-channel-and-direct-messages)

<img width="1071" alt="image" src="https://user-images.githubusercontent.com/2871786/219030941-84dcd0d2-6582-4462-b21f-d1a5fb7dcb3c.png">

