### PR TITLE
maven: upgrade target to 7

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -70,6 +70,4 @@ export JAVA_HOME
 PATH=$JAVA_HOME/bin:$PATH
 export PATH
 
-echo "--- Debug JDK installation :coffee:"
-tree "$JAVA_HOME" || true
 java -version || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   MAVEN_CONFIG: "-V -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25"
-  JAVA_VERSION: 11
+  JAVA_VERSION: 17
   JAVA_DIST: adopt
 
 jobs:

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
     <properties>
         <version.junit-jupiter>5.5.1</version.junit-jupiter>
-        <maven.compiler.target>6</maven.compiler.target>
+        <maven.compiler.target>7</maven.compiler.target>
         <maven.compiler.testTarget>10</maven.compiler.testTarget>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Otherwise, when using JDK17, the same as the APM AGent java, it will cause an error

```
[INFO] -------------------------------------------------------------
--
  | [ERROR] COMPILATION ERROR :
  | [INFO] -------------------------------------------------------------
  | [ERROR] Source option 6 is no longer supported. Use 7 or later.
  | [ERROR] Target option 6 is
```
