### PR TITLE
ci(release): use new set of credentials for GPG and Maven Central 

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,0 +1,27 @@
+# Buildkite
+This README overviews the Buildkite pipelines that automate the build and publishing processes.
+
+## Release pipeline
+
+The Buildkite pipeline for the ECS Logging Java is responsible for the releases.
+
+### Pipeline Configuration
+
+To view the pipeline and its configuration, click [here](https://buildkite.com/elastic/ecs-logging-java-release) or
+go to the definition in the `elastic/ci` repository.
+
+### Credentials
+
+The release team provides the credentials required to publish the artifacts in Maven Central and sign them
+with the GPG.
+
+If further details are needed, please go to [pre-command](hooks/pre-command).
+
+## Snapshot pipeline
+
+The Buildkite pipeline for the APM Agent Java is responsible for the snapshots.
+
+### Pipeline Configuration
+
+To view the pipeline and its configuration, click [here](https://buildkite.com/elastic/ecs-logging-java-snapshot) or
+go to the definition in the `elastic/ci` repository.

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -28,7 +28,7 @@ export SERVER_PASSWORD
 
 # Signing keys
 GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/ecs-logging/gpg
-vault read -field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
+vault kv get --field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
 ## NOTE: This is not a typo. "passphase" is the name of the field.
 KEYPASS_SECRET=$(vault kv get --field="passphase" $GPG_SECRET)
 export KEYPASS_SECRET

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -21,16 +21,16 @@ chmod -R 700 $TMP_WORKSPACE
 echo "--- Prepare keys context :key:"
 # Nexus credentials
 NEXUS_SECRET=kv/ci-shared/release-eng/team-release-secrets/ecs-logging/maven_central
-SERVER_USERNAME=$(vault read -field username $NEXUS_SECRET)
+SERVER_USERNAME=$(vault kv get --field="username" $NEXUS_SECRET)
 export SERVER_USERNAME
-SERVER_PASSWORD=$(vault read -field password $NEXUS_SECRET)
+SERVER_PASSWORD=$(vault kv get --field="password" $NEXUS_SECRET)
 export SERVER_PASSWORD
 
 # Signing keys
 GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/ecs-logging/gpg
 vault read -field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
 ## NOTE: This is not a typo. "passphase" is the name of the field.
-KEYPASS_SECRET=$(vault read -field="passphase" $GPG_SECRET)
+KEYPASS_SECRET=$(vault kv get --field="passphase" $GPG_SECRET)
 export KEYPASS_SECRET
 KEY_ID=$(vault kv get --field="key_id" $GPG_SECRET)
 KEY_ID_SECRET=${KEY_ID: -8}

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -29,7 +29,7 @@ export SERVER_PASSWORD
 # Signing keys
 GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/ecs-logging/gpg
 vault read -field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
-## NOTE: passphase is the name of the field.
+## NOTE: This is not a typo. "passphase" is the name of the field.
 KEYPASS_SECRET=$(vault read -field="passphase" $GPG_SECRET)
 export KEYPASS_SECRET
 KEY_ID=$(vault kv get --field="key_id" $GPG_SECRET)

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,21 +8,6 @@
 
 set -eo pipefail
 
-echo "--- Prepare vault context :vault:"
-VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_ROLE_ID_SECRET
-
-VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_SECRET_ID_SECRET
-
-VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-ecs-logging-java/internal-ci-approle)
-export VAULT_ADDR
-
-# Delete the vault specific accessing the ci vault
-PREVIOUS_VAULT_TOKEN=$VAULT_TOKEN
-export PREVIOUS_VAULT_TOKEN
-unset VAULT_TOKEN
-
 echo "--- Prepare a secure temp :closed_lock_with_key:"
 # Prepare a secure temp folder not shared between other jobs to store the key ring
 export TMP_WORKSPACE=/tmp/secured
@@ -34,20 +19,22 @@ mkdir -p $GNUPGHOME
 chmod -R 700 $TMP_WORKSPACE
 
 echo "--- Prepare keys context :key:"
-VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
-export VAULT_TOKEN
-
 # Nexus credentials
-SERVER_USERNAME=$(vault read -field username secret/release/nexus)
+NEXUS_SECRET=kv/ci-shared/release-eng/team-release-secrets/ecs-logging/maven_central
+SERVER_USERNAME=$(vault read -field username $NEXUS_SECRET)
 export SERVER_USERNAME
-SERVER_PASSWORD=$(vault read -field password secret/release/nexus)
+SERVER_PASSWORD=$(vault read -field password $NEXUS_SECRET)
 export SERVER_PASSWORD
 
 # Signing keys
-vault read -field=key secret/release/signing >$KEY_FILE
-KEYPASS_SECRET=$(vault read -field=passphrase secret/release/signing)
+GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/ecs-logging/gpg
+vault read -field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
+## NOTE: passphase is the name of the field.
+KEYPASS_SECRET=$(vault read -field="passphase" $GPG_SECRET)
 export KEYPASS_SECRET
-export KEY_ID_SECRET=D88E42B4
+KEY_ID=$(vault kv get --field="key_id" $GPG_SECRET)
+KEY_ID_SECRET=${KEY_ID: -8}
+export KEY_ID_SECRET
 
 # Import the key into the keyring
 echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -27,7 +27,7 @@ SERVER_PASSWORD=$(vault kv get --field="password" $NEXUS_SECRET)
 export SERVER_PASSWORD
 
 # Signing keys
-GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/ecs-logging/gpg
+GPG_SECRET=kv/ci-shared/release-eng/team-release-secrets/ecs-logging/gpg
 vault kv get --field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
 ## NOTE: This is not a typo. "passphase" is the name of the field.
 KEYPASS_SECRET=$(vault kv get --field="passphase" $GPG_SECRET)


### PR DESCRIPTION
### What

Use the Vault secrets accessed to run the Release/Snapshots.

Those secrets are managed by the Release team and they provided specific ones for this project.

### Why

The release team requested to use them.