### PR TITLE
Fix pre-post release workflow: missing inputs field

### DIFF
--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -3,20 +3,21 @@ name: Pre/Post Release
 
 on:
   workflow_call:
-    ref:
-      description: 'Branch or tag ref to run the workflow on'
-      required: true
-      default: 'main'
-    version:
-      description: 'The version to release (e.g. 1.2.3). This workflow will automatically perform the required version bumps'
-      required: true
-    phase:
-      description: 'Pre or post release phase'
-      type: choice
-      options:
-        - pre
-        - post
-      required: true
+    inputs:
+      ref:
+        description: 'Branch or tag ref to run the workflow on'
+        required: true
+        default: 'main'
+      version:
+        description: 'The version to release (e.g. 1.2.3). This workflow will automatically perform the required version bumps'
+        required: true
+      phase:
+        description: 'Pre or post release phase'
+        type: choice
+        options:
+          - pre
+          - post
+        required: true
 
 env:
   RELEASE_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
Trying to trigger the pre-release job yielded the following error:
```
[Invalid workflow file: .github/workflows/pre-release.yml#L21](https://github.com/elastic/ecs-logging-java/actions/runs/7902626610/workflow)
The workflow is not valid. In .github/workflows/pre-release.yml (Line: 21, Col: 11): Error from called workflow elastic/ecs-logging-java/.github/workflows/pre-post-release.yml@43a916f13657d1c9941332340219b447347e5c4e (Line: 6, Col: 5): Unexpected value 'ref' In .github/workflows/pre-release.yml (Line: 21, Col: 11): Error from called workflow elastic/ecs-logging-java/.github/workflows/pre-post-release.yml@43a916f13657d1c9941332340219b447347e5c4e (Line: 10, Col: 5): Unexpected value 'version'
```

Based on my reading of the docs the input variables should be nested under an `inputs` field