### PR TITLE
Fix pre-release workflow

### DIFF
--- a/.github/workflows/pre-post-release.yml
+++ b/.github/workflows/pre-post-release.yml
@@ -25,9 +25,6 @@ env:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}
-
 jobs:
   validate-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   contents: read
 
+
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   validate-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Context

The pre release workflow is failing instantly with a deadlock in https://github.com/elastic/ecs-logging-java/actions/runs/7912945522

```
Canceling since a deadlock for concurrency group 'Pre release' was detected between 'top level workflow' and 'pre-release'
```

## Change

This change moves the concurrency settings to the parent workflows in all places where the `pre-post-release.yml` workflows is used as "sub"-workflow. 

Currently the pre-post-release workflow is used only in [release.yml ](https://github.com/elastic/ecs-logging-java/blob/fd642a7b52a33d88b23c9d22d686f079d7c3ca3c/.github/workflows/release.yml#L90)and [pre-release.yml](https://github.com/elastic/ecs-logging-java/blob/537cd36df3da3b46ac3bc48ad2f357433c140ecb/.github/workflows/pre-release.yml#L21). Whereas the pre-release workflow already had the concurrency settings.