### PR TITLE
ci(snapshot): skip deploy if no snapshot version or release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Validate tag does not exist on current commit
         uses: ./.github/workflows/validate-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,6 @@ jobs:
             echo "Tag should match pom.xml project.version"
             exit 1
           fi
-      - uses: ./.github/workflows/maven-goal
-        with:
-          command: './mvnw -q help:evaluate -Dexpression=project.version -DforceStdout'
       - name: Validate version is a release version
         run: |
           if [[ "$(./mvnw -q help:evaluate -Dexpression=project.version -DforceStdout)" =~ "-SNAPSHOT" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,15 @@ jobs:
             echo "Tag should match pom.xml project.version"
             exit 1
           fi
+      - uses: ./.github/workflows/maven-goal
+        with:
+          command: './mvnw -q help:evaluate -Dexpression=project.version -DforceStdout'
+      - name: Validate version is a release version
+        run: |
+          if [[ "$(./mvnw -q help:evaluate -Dexpression=project.version -DforceStdout)" =~ "-SNAPSHOT" ]]; then
+            echo "This is a snapshot version"
+            exit 1
+          fi
 
   release:
     name: Release

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -19,6 +19,9 @@ jobs:
       is-snapshot: ${{ steps.validate.outputs.is-snapshot }}
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/workflows/maven-goal
+        with:
+          command: './mvnw -q help:evaluate -Dexpression=project.version -DforceStdout'
       - name: Validate version is a snapshot version
         id: validate
         run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,10 +13,27 @@ on:
         type: boolean
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      is-snapshot: ${{ steps.validate.outputs.is-snapshot }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate version is a snapshot version
+        id: validate
+        run: |
+          output=false
+          if [[ "$(./mvnw -q help:evaluate -Dexpression=project.version -DforceStdout)" =~ "-SNAPSHOT" ]]; then
+            echo "This is a snapshot version"
+            output=true
+          fi
+          echo "is-snapshot=$output" >> "$GITHUB_OUTPUT"
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-
+    needs: validate
+    if: ${{ needs.validate.outputs.is-snapshot == true}}
     steps:
       - id: buildkite
         name: Run Deploy

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -33,7 +33,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: validate
-    if: ${{ needs.validate.outputs.is-snapshot == true}}
+    if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
     steps:
       - id: buildkite
         name: Run Deploy

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -19,9 +19,6 @@ jobs:
       is-snapshot: ${{ steps.validate.outputs.is-snapshot }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/workflows/maven-goal
-        with:
-          command: './mvnw -q help:evaluate -Dexpression=project.version -DforceStdout'
       - name: Validate version is a snapshot version
         id: validate
         run: |


### PR DESCRIPTION
### What

- Don't run a snapshot deployment if the version is not a snapshot.
- Don't run a release deployment if the version is a snapshot.

### Why

The release process has been changed to accommodate the branch protection, and hence, the main will contain a release version until the PR with the snapshot version is merged. 

Therefore, the snapshot GitHub action will run when it should not!

In addition, let's avoid the corner case where the `pom.xml` file contains a SNAPSHOT version and the `inputs.ref` points to that particular git reference.

### Test


<img width="1417" alt="image" src="https://github.com/elastic/ecs-logging-java/assets/2871786/4fd621ff-142e-487f-aed6-80ef003740f3">


### Issues

Caused by https://github.com/elastic/ecs-logging-java/pull/226