### PR TITLE
bk: use specialised bk runners

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -1,6 +1,6 @@
 agents:
   provider: "gcp"
-  #image: "family/ecs-logging-java-ubuntu-2204"
+  image: "family/ecs-logging-java-ubuntu-2204"
 
 steps:
   - label: "Run the release"

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -1,6 +1,6 @@
 agents:
   provider: "gcp"
-  #image: "family/ecs-logging-java-ubuntu-2204"
+  image: "family/ecs-logging-java-ubuntu-2204"
 
 steps:
   - label: "Run the snapshot"


### PR DESCRIPTION
Does what it says in the tin


Snapshot [build](https://buildkite.com/elastic/ecs-logging-java-snapshot/builds/41) in Buildkite. (ONly available for Elastic employees)
