### PR TITLE
github-actions: enable provenance for the jar files

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -3,7 +3,7 @@ agents:
   image: "family/ecs-logging-java-ubuntu-2204"
 
 env:
-  TARBALL_FILE: ${TARBALL_FILE:-dist.tar}
+  TARBALL_FILE: ${TARBALL_FILE:-artifacts.tar}
 
 steps:
   - label: "Run the release"

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -2,11 +2,16 @@ agents:
   provider: "gcp"
   image: "family/ecs-logging-java-ubuntu-2204"
 
+env:
+  TARBALL_FILE: ${TARBALL_FILE:-dist.tar}
+
 steps:
   - label: "Run the release"
     key: "release"
     commands: .ci/release.sh
-    artifact_paths: "release.txt"
+    artifact_paths:
+      - "release.txt"
+      - "${TARBALL_FILE}"
 
 notify:
   - slack: "#apm-agent-java"

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -2,6 +2,9 @@ agents:
   provider: "gcp"
   image: "family/ecs-logging-java-ubuntu-2204"
 
+env:
+  TARBALL_FILE: ${TARBALL_FILE:-dist.tar}
+
 steps:
   - label: "Run the snapshot"
     key: "release"
@@ -9,6 +12,7 @@ steps:
     artifact_paths:
       - "snapshot.txt"
       - "**/target/*"
+      - "${TARBALL_FILE}"
 
 notify:
   - slack: "#apm-agent-java"

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -3,7 +3,7 @@ agents:
   image: "family/ecs-logging-java-ubuntu-2204"
 
 env:
-  TARBALL_FILE: ${TARBALL_FILE:-dist.tar}
+  TARBALL_FILE: ${TARBALL_FILE:-artifacts.tar}
 
 steps:
   - label: "Run the snapshot"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -38,3 +38,6 @@ fi
 
 echo "--- Release the binaries to Maven Central :maven: [./mvnw ${GOAL})] ${DRY_RUN_MSG}"
 ./mvnw -V -s .ci/settings.xml -Pgpg clean $GOAL -DskipTests --batch-mode | tee release.txt
+
+echo "--- Archive the target folder with jar files"
+find . -type d -name target -exec find {} -name '*.jar' -print0 \; | xargs -0 tar -cvf "${TARBALL_FILE:-dist.tar}"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -40,4 +40,5 @@ echo "--- Release the binaries to Maven Central :maven: [./mvnw ${GOAL})] ${DRY_
 ./mvnw -V -s .ci/settings.xml -Pgpg clean $GOAL -DskipTests --batch-mode | tee release.txt
 
 echo "--- Archive the target folder with jar files"
-find . -type d -name target -exec find {} -name '*.jar' -print0 \; | xargs -0 tar -cvf "${TARBALL_FILE:-dist.tar}"
+.ci/published-artifacts-list.sh | tee artifacts.list
+tar -cvf "${TARBALL_FILE:-artifacts.tar}" -T artifacts.list

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -37,4 +37,5 @@ echo "--- Deploy the snapshot :package: [./mvnw ${GOAL})] ${DRY_RUN_MSG}"
 ./mvnw -V -s .ci/settings.xml -Pgpg clean ${GOAL} -DskipTests --batch-mode | tee snapshot.txt
 
 echo "--- Archive the target folder with jar files"
-find . -type d -name target -exec find {} -name '*.jar' -print0 \; | xargs -0 tar -cvf "${TARBALL_FILE:-dist.tar}"
+.ci/published-artifacts-list.sh | tee artifacts.list
+tar -cvf "${TARBALL_FILE:-artifacts.tar}" -T artifacts.list

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -35,3 +35,6 @@ fi
 
 echo "--- Deploy the snapshot :package: [./mvnw ${GOAL})] ${DRY_RUN_MSG}"
 ./mvnw -V -s .ci/settings.xml -Pgpg clean ${GOAL} -DskipTests --batch-mode | tee snapshot.txt
+
+echo "--- Archive the target folder with jar files"
+find . -type d -name target -exec find {} -name '*.jar' -print0 \; | xargs -0 tar -cvf "${TARBALL_FILE:-dist.tar}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       contents: write
       id-token: write
     env:
-      TARBALL_FILE: dist.tar
+      TARBALL_FILE: artifacts.tar
     steps:
       - id: buildkite
         name: Run Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
     if: ${{ ! inputs.skip_maven_deploy }}
     needs:
       - validate-tag
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      TARBALL_FILE: dist.tar
     steps:
       - id: buildkite
         name: Run Release
@@ -75,11 +80,26 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ecs-logging-java-release
+          artifactName: releases
+          artifactPath: ${{ env.TARBALL_FILE }}
           waitFor: true
           printBuildLogs: false
           buildEnvVars: |
             ref=${{ inputs.ref }}
             dry_run=${{ inputs.dry_run || 'false' }}
+            TARBALL_FILE=${{ env.TARBALL_FILE }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: releases
+
+      - name: untar the buildkite tarball
+        run: tar xvf ${{ env.TARBALL_FILE }}
+
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: "${{ github.workspace }}/**/target/*.jar"
 
       - if: ${{ success() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -37,6 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate
     if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      TARBALL_FILE: dist.tar
     steps:
       - id: buildkite
         name: Run Deploy
@@ -46,10 +51,25 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ecs-logging-java-snapshot
-          waitFor: false
+          artifactName: snapshots
+          artifactPath: ${{ env.TARBALL_FILE }}
+          waitFor: true
           printBuildLogs: false
           buildEnvVars: |
             dry_run=${{ inputs.dry_run || 'false' }}
+            TARBALL_FILE=${{ env.TARBALL_FILE }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: snapshots
+
+      - name: untar the buildkite tarball
+        run: tar xvf ${{ env.TARBALL_FILE }}
+
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: "${{ github.workspace }}/**/target/*.jar"
 
       - if: ${{ failure() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,7 +41,7 @@ jobs:
       contents: write
       id-token: write
     env:
-      TARBALL_FILE: dist.tar
+      TARBALL_FILE: artifacts.tar
     steps:
       - id: buildkite
         name: Run Deploy


### PR DESCRIPTION
## What does this PR do?

Enable the provenance for the jar files generated in Buildkite using the [GitHub provenance action](https://github.com/github-early-access/generate-build-provenance).

### Test 

I tested it in [here](https://github.com/elastic/ecs-logging-java/actions/runs/8818371698) using a test feature branch, and it produced these attestations:
- https://github.com/elastic/ecs-logging-java/attestations

Similar to https://github.com/elastic/apm-agent-java/pull/3594