### PR TITLE
add script to get published artifacts

### DIFF
--- a/.ci/published-artifacts-list.sh
+++ b/.ci/published-artifacts-list.sh
@@ -1,0 +1,2 @@
+#!/bin/env bash
+find . -name '*.jar'|grep '/target/'|grep -v javadoc|grep -v sources|grep -v '\-tests.jar'


### PR DESCRIPTION
Adds `.ci/published-artifacts-list.sh` script to list the published artifacts.

Sample output:

```
./log4j-ecs-layout/target/log4j-ecs-layout-1.6.1-SNAPSHOT.jar
./logback-legacy-tests/target/logback-legacy-tests-1.6.1-SNAPSHOT.jar
./log4j-legacy-tests/target/log4j-legacy-tests-1.6.1-SNAPSHOT.jar
./jboss-logmanager-ecs-formatter/target/jboss-logmanager-ecs-formatter-1.6.1-SNAPSHOT.jar
./logback-ecs-encoder/target/logback-ecs-encoder-1.6.1-SNAPSHOT.jar
./jul-ecs-formatter/target/jul-ecs-formatter-1.6.1-SNAPSHOT.jar
./log4j2-legacy-tests/target/log4j2-legacy-tests-1.6.1-SNAPSHOT.jar
./ecs-logging-core/target/ecs-logging-core-1.6.1-SNAPSHOT.jar
./log4j2-ecs-layout/target/log4j2-ecs-layout-1.6.1-SNAPSHOT.jar
```