### PR TITLE
github-action: add attestations scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
     needs:
       - validate-tag
     permissions:
+      attestations: write
       contents: write
       id-token: write
     env:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -38,6 +38,7 @@ jobs:
     needs: validate
     if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
     permissions:
+      attestations: write
       contents: write
       id-token: write
     env:


### PR DESCRIPTION
> The attestations permission is necessary to persist the attestation.

As per [docs](https://github.com/github-early-access/generate-build-provenance?tab=readme-ov-file#usage)