### PR TITLE
github-action: run buildkite action with GH secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,26 +73,24 @@ jobs:
     env:
       TARBALL_FILE: artifacts.tar
     steps:
-      - id: buildkite
+      - id: buildkite-run
         name: Run Release
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        uses: elastic/oblt-actions/buildkite/run@v1.5.0
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ecs-logging-java-release
-          artifactName: releases
-          artifactPath: ${{ env.TARBALL_FILE }}
-          waitFor: true
-          printBuildLogs: false
-          buildEnvVars: |
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: true
+          env-vars: |
             ref=${{ inputs.ref }}
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
         with:
-          name: releases
+          build-number: ${{ steps.buildkite-run.outputs.number }}
+          path: ${{ env.TARBALL_FILE }}
+          pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
+          token: ${{ secrets.BUILDKITE_TOKEN }}
 
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}
@@ -103,15 +101,15 @@ jobs:
           subject-path: "${{ github.workspace }}/**/target/*.jar"
 
       - if: ${{ success() }}
-        uses: elastic/oblt-actions/slack/send@v1.2.0
+        uses: elastic/oblt-actions/slack/send@v1.5.0
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-java"
           message: |
-            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite.outputs.build }}|build>)
+            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite-run.outputs.build }}|build>)
 
       - if: ${{ failure() }}
-        uses: elastic/oblt-actions/slack/send@v1.2.0
+        uses: elastic/oblt-actions/slack/send@v1.5.0
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-java"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -44,25 +44,16 @@ jobs:
     env:
       TARBALL_FILE: artifacts.tar
     steps:
-      - id: buildkite
+      - id: buildkite-run
         name: Run Deploy
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        uses: elastic/oblt-actions/buildkite/run@v1.5.0
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ecs-logging-java-snapshot
-          artifactName: snapshots
-          artifactPath: ${{ env.TARBALL_FILE }}
-          waitFor: true
-          printBuildLogs: false
-          buildEnvVars: |
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: true
+          env-vars: |
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: snapshots
 
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}
@@ -73,7 +64,7 @@ jobs:
           subject-path: "${{ github.workspace }}/**/target/*.jar"
 
       - if: ${{ failure() }}
-        uses: elastic/oblt-actions/slack/send@v1.2.0
+        uses: elastic/oblt-actions/slack/send@v1.5.0
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-java"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -55,6 +55,13 @@ jobs:
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
+        with:
+          build-number: ${{ steps.buildkite-run.outputs.number }}
+          path: ${{ env.TARBALL_FILE }}
+          pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}
 


### PR DESCRIPTION
Use GitHub secrets to run the Buildkite release/snapshot

No more Vault secrets access.

There is a pending task to replace the GitHub token user.


### Tests

I created a feature branch called `test/buildkite-token` and triggered a dry-run snapshot:
- https://github.com/elastic/ecs-logging-java/actions/runs/9365973088