### PR TITLE
github-action: use ephemeral tokens with the required permissions

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -17,6 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+
       - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
@@ -27,13 +39,13 @@ jobs:
         with:
           command: --experimental compose diff
         env:
-          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose apply
         env:
-          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - if: failure()
         uses: elastic/oblt-actions/slack/send@v1


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

### What

Use https://github.com/tibdex/github-app-token to generate ephemeral tokens with the required
permissions only

This is the alternative to moving away from finer-grained GitHub tokens and reducing the
cumbersome of rotating them as we do nowadays.

### Implementaiton details

We have used the same GitHub action in other places.

If there are any questions, please reach out to the @elastic/observablt-ci
