### PR TITLE
github-action: use oblt-actions/pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
-    - uses: elastic/apm-pipeline-library/.github/actions/pre-commit@current
+    - uses: elastic/oblt-actions/pre-commit@v1
 
   goals:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been deprecated in favor of 
https://github.com/elastic/oblt-actions.

Requires https://github.com/elastic/oblt-actions/pull/119 to be merged.

If there are any questions, please reach out to the @elastic/observablt-ci
