### PR TITLE
github-actions: use ephemeral tokens with the right permissions

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -4,8 +4,6 @@ name: Auto Assign to Project(s)
 on:
   issues:
     types: [opened, edited, milestoned]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 
 permissions:
   contents: read
@@ -15,6 +13,18 @@ jobs:
     runs-on: ubuntu-latest
     name: Assign milestoned to Project
     steps:
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "organization_projects": "write",
+            "issues": "read"
+          }
+
     - name: Assign issues with milestones to project
       uses: elastic/assign-one-project-github-action@1.2.2
       if: github.event.issue && github.event.issue.milestone
@@ -22,3 +32,5 @@ jobs:
         project: 'https://github.com/orgs/elastic/projects/454'
         project_id: '5882982'
         column_name: 'Planned'
+      env:
+        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,6 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 
 permissions:
   contents: read
@@ -22,6 +20,18 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-config.yml
         enable-versioned-regex: 0
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "members": "read",
+            "organization_projects": "write",
+            "issues": "read"
+          }
     - name: Check team membership for user
       uses: elastic/get-user-teams-membership@1.1.0
       id: checkUserMember
@@ -32,7 +42,7 @@ jobs:
           apmmachine
           dependabot
           obltmachine
-        GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
     - name: Show team membership
       run: |
         echo "::debug::isTeamMember: ${{ steps.checkUserMember.outputs.isTeamMember }}"
@@ -51,3 +61,5 @@ jobs:
         project: 'https://github.com/orgs/elastic/projects/454'
         project_id: '5882982'
         column_name: 'In Progress'
+      env:
+        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
A similar implementation was done in https://github.com/elastic/apm-agent-java/pull/3829