### PR TITLE
github-actions: use v1 for the oblt-actions

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - id: buildkite-run
         name: Run Release
-        uses: elastic/oblt-actions/buildkite/run@v1.5.0
+        uses: elastic/oblt-actions/buildkite/run@v1
         with:
           pipeline: ecs-logging-java-release
           token: ${{ secrets.BUILDKITE_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1
         with:
           build-number: ${{ steps.buildkite-run.outputs.number }}
           path: ${{ env.TARBALL_FILE }}
@@ -101,7 +101,7 @@ jobs:
           subject-path: "${{ github.workspace }}/**/target/*.jar"
 
       - if: ${{ success() }}
-        uses: elastic/oblt-actions/slack/send@v1.5.0
+        uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-java"
@@ -109,7 +109,7 @@ jobs:
             :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite-run.outputs.build }}|build>)
 
       - if: ${{ failure() }}
-        uses: elastic/oblt-actions/slack/send@v1.5.0
+        uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-java"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - id: buildkite-run
         name: Run Deploy
-        uses: elastic/oblt-actions/buildkite/run@v1.5.0
+        uses: elastic/oblt-actions/buildkite/run@v1
         with:
           pipeline: ecs-logging-java-snapshot
           token: ${{ secrets.BUILDKITE_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1
         with:
           build-number: ${{ steps.buildkite-run.outputs.number }}
           path: ${{ env.TARBALL_FILE }}
@@ -71,7 +71,7 @@ jobs:
           subject-path: "${{ github.workspace }}/**/target/*.jar"
 
       - if: ${{ failure() }}
-        uses: elastic/oblt-actions/slack/send@v1.5.0
+        uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-java"


### PR DESCRIPTION
dependabot does not bump version for githubactions using semver and 'v1', see https://github.com/dependabot/dependabot-core/issues/10924