### PR TITLE
ci: use tool-versions for updatecli

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -38,12 +38,14 @@ jobs:
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose diff
+          version-file: .tool-versions
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose apply
+          version-file: .tool-versions
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+updatecli v0.88.0

--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -11,3 +11,7 @@ policies:
     values:
       - .ci/updatecli/values.d/scm.yml
       - .ci/updatecli/values.d/update-compose.yml
+  - name: Update Updatecli version
+    policy: ghcr.io/elastic/oblt-updatecli-policies/updatecli/version:0.2.0@sha256:013a37ddcdb627c46e7cba6fb9d1d7bc144584fa9063843ae7ee0f6ef26b4bea
+    values:
+      - .ci/updatecli/values.d/scm.yml


### PR DESCRIPTION
### What does this PR do?

Use a file to host the updatecli version
Bump the version using the updatecli policy for that.

See https://github.com/elastic/apm-agent-java/pull/3901