### PR TITLE
Add support for new spring boot rolling policy properties

### DIFF
--- a/logback-ecs-encoder/src/main/resources/co/elastic/logging/logback/boot/ecs-file-appender.xml
+++ b/logback-ecs-encoder/src/main/resources/co/elastic/logging/logback/boot/ecs-file-appender.xml
@@ -13,11 +13,12 @@ ECS JSON file appender logback configuration provided for import, similar to the
         </encoder>
         <file>${LOG_FILE}.json</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <cleanHistoryOnStart>${LOG_FILE_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
-            <fileNamePattern>${ROLLING_FILE_NAME_PATTERN:-${LOG_FILE}.json.%d{yyyy-MM-dd}.%i.gz}</fileNamePattern>
-            <maxFileSize>${LOG_FILE_MAX_SIZE:-10MB}</maxFileSize>
-            <maxHistory>${LOG_FILE_MAX_HISTORY:-7}</maxHistory>
-            <totalSizeCap>${LOG_FILE_TOTAL_SIZE_CAP:-0}</totalSizeCap>
+            <!-- LOGBACK_ROLLINGPOLICY_ env variables are for Spring Boot 3+, the LOG_FILE_ variables for spring boot 2 -->
+            <cleanHistoryOnStart>${LOG_FILE_CLEAN_HISTORY_ON_START:-${LOGBACK_ROLLINGPOLICY_CLEAN_HISTORY_ON_START:-false}}</cleanHistoryOnStart>
+            <fileNamePattern>${ROLLING_FILE_NAME_PATTERN:-${LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN:-${LOG_FILE}.json.%d{yyyy-MM-dd}.%i.gz}}</fileNamePattern>
+            <maxFileSize>${LOG_FILE_MAX_SIZE:-${LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE:-10MB}}</maxFileSize>
+            <maxHistory>${LOG_FILE_MAX_HISTORY:-${LOGBACK_ROLLINGPOLICY_MAX_HISTORY:-7}}</maxHistory>
+            <totalSizeCap>${LOG_FILE_TOTAL_SIZE_CAP:-${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP:-0}}</totalSizeCap>
         </rollingPolicy>
     </appender>
 </included>


### PR DESCRIPTION
Closes #276 .
It looks like from spring boot 2.3 to 2.4+ the config names for configuring the rollover strategy have changed:
 * [Spring boot docs 2.3](https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/htmlsingle/#boot-features-logging-file-output)
 * [Spring boot docs 2.4](https://docs.spring.io/spring-boot/docs/2.4.x/reference/htmlsingle/#boot-features-logging-file-rotation)
 
This change makes use of nested variable substitution to support both variable variants. Tested manually with spring boot 2.3, 2.4 and 3.3. 