### PR TITLE
Fix to suppert JPMS

### DIFF
--- a/ecs-logging-core/src/main/java/module-info.java
+++ b/ecs-logging-core/src/main/java/module-info.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+module co.elastic.logging {
+
+  requires java.base;
+  exports co.elastic.logging;
+
+}
+

--- a/logback-ecs-encoder/pom.xml
+++ b/logback-ecs-encoder/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.13</version>
+            <version>1.3.15</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/logback-ecs-encoder/src/main/java/module-info.java
+++ b/logback-ecs-encoder/src/main/java/module-info.java
@@ -1,0 +1,36 @@
+/*-
+ * #%L
+ * Java ECS logging
+ * %%
+ * Copyright (C) 2019 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+module logback.ecs.encoder {
+
+  requires java.base;
+  requires org.slf4j;
+  requires co.elastic.logging;
+  requires ch.qos.logback.core;
+  requires ch.qos.logback.classic;
+
+  exports co.elastic.logging.logback;
+
+}
+


### PR DESCRIPTION
This is a fix for #332.

This change needs to update the dependency of logback-classic from 1.2.13 to 1.3.15, because 1.3.x is the first version, which supports JPMS, i.e. it including the needed module-info file.

Only in the main project ecs-logging-core and in logback-ecs-encoder the module-info file has been added. Also in jul-ecs-formatter and log4j-* projects a module-info file could be added in a similar way.