### PR TITLE
github-action: add artifact-metadata permission for attestations

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -67,6 +67,7 @@ jobs:
     needs:
       - validate-tag
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: write
       id-token: write

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -38,6 +38,7 @@ jobs:
     needs: validate
     if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: write
       id-token: write


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

The attestations permission is necessary to persist the attestation. 
The artifact-metadata permission is required to generate artifact metadata storage records.

This change adds `artifact-metadata: write` permission to workflows that have 
`attestations: write` permission, as required by the actions/attest-build-provenance action.

See:
* https://github.com/marketplace/actions/attest-build-provenance#usage
* https://github.blog/changelog/2026-01-20-strengthen-your-supply-chain-with-code-to-cloud-traceability-and-slsa-build-level-3-security/

If there are any questions, please reach out to the @elastic/observablt-ci
