### PR TITLE
docs: add `applies_to` frontmatter and scope Filebeat section to stack

### DIFF
--- a/docs/reference/_structured_logging_with_log4j2.md
+++ b/docs/reference/_structured_logging_with_log4j2.md
@@ -1,6 +1,11 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/java/current/_structured_logging_with_log4j2.html
+products:
+  - id: ecs-logging
 ---
 
 # Structured logging with log4j2 [_structured_logging_with_log4j2]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,7 +1,12 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/java/current/intro.html
   - https://www.elastic.co/guide/en/ecs-logging/java/current/index.html
+products:
+  - id: ecs-logging
 ---
 
 # ECS Logging Java [intro]

--- a/docs/reference/setup.md
+++ b/docs/reference/setup.md
@@ -1,7 +1,12 @@
 ---
+applies_to:
+  stack: ga
+  serverless: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/ecs-logging/java/current/setup.html
 navigation_title: Get started
+products:
+  - id: ecs-logging
 ---
 
 # Get started with ECS Logging Java [setup]
@@ -383,6 +388,11 @@ If you’re using the Elastic APM Java agent, log correlation is enabled by defa
 
 ## Step 2: Configure Filebeat [setup-step-2]
 
+```{applies_to}
+stack: ga
+serverless: unavailable
+```
+
 :::::::{tab-set}
 
 ::::::{tab-item} Log file
@@ -475,6 +485,11 @@ For more information, see the [Filebeat reference](beats://reference/filebeat/co
 
 
 ### When `stackTraceAsArray` is enabled [setup-stack-trace-as-array]
+
+```{applies_to}
+stack: ga
+serverless: unavailable
+```
 
 Filebeat can normally only decode JSON if there is one JSON object per line. When `stackTraceAsArray` is enabled, there will be a new line for each stack trace element which improves readability. But when combining the multiline settings with a `decode_json_fields` we can also handle multi-line JSON:
 


### PR DESCRIPTION
## Summary

Adds mandatory `applies_to` (and `products`) frontmatter to all reference docs and adds section-level `applies_to` where content is stack-only, per the [Docs Versioning contributor guidelines](https://www.elastic.co/docs/contribute-docs/how-to/cumulative-docs) and [applies_to syntax](https://elastic.github.io/docs-builder/syntax/applies/).

Relates to [#256](https://github.com/elastic/docs-content-internal/issues/256)

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Claude Sonnet 4.5 using Cursor to double-check the updated files, write PR description