### PR TITLE
Avoid automatic version bumping for legacy tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
+    exclude-paths:
+      - "log4j2-legacy-tests"
+      - "log4j-legacy-tests"
+      - "logback-legacy-tests"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Excluding legacy tests from getting automatic version bump PRs from dependabot, as we don't want to bump those versions. References:

* https://github.com/elastic/ecs-logging-java/pull/165
* https://github.com/elastic/ecs-logging-java/pull/373