### PR TITLE
add missing project.name in some pom.xml

### DIFF
--- a/ecs-logging-core/pom.xml
+++ b/ecs-logging-core/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ecs-logging-core</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
     <properties>
         <parent.base.dir>${project.basedir}/..</parent.base.dir>
     </properties>

--- a/log4j-legacy-tests/pom.xml
+++ b/log4j-legacy-tests/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>log4j-legacy-tests</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <parent.base.dir>${project.basedir}/..</parent.base.dir>

--- a/log4j2-legacy-tests/pom.xml
+++ b/log4j2-legacy-tests/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>log4j2-legacy-tests</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <version.log4j.legacy>2.6</version.log4j.legacy>

--- a/logback-legacy-tests/pom.xml
+++ b/logback-legacy-tests/pom.xml
@@ -8,6 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>logback-legacy-tests</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <parent.base.dir>${project.basedir}/..</parent.base.dir>


### PR DESCRIPTION
release failed with an error about missing "project name" for ecs-logging-core dependency, I guess this is a new requirement since last release for publication.