### PR TITLE
fix: disable maven cache in release workflow

### DIFF
--- a/.github/workflows/maven-goal/action.yml
+++ b/.github/workflows/maven-goal/action.yml
@@ -24,6 +24,8 @@ runs:
       with:
         java-version-file: .java-version
         distribution: ${{ inputs.distribution }}
+        # cache intentionally disabled (cache poisoning risk): shared by CI and release
+        # workflows with no per-caller toggle, so it's off everywhere. elastic/observability-robots#3261
     - run: "${COMMAND}"
       shell: ${{ inputs.shell }}
       env:

--- a/.github/workflows/maven-goal/action.yml
+++ b/.github/workflows/maven-goal/action.yml
@@ -20,11 +20,10 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v6
       with:
         java-version-file: .java-version
         distribution: ${{ inputs.distribution }}
-        cache: 'maven'
     - run: "${COMMAND}"
       shell: ${{ inputs.shell }}
       env:

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -3,3 +3,4 @@
 -Dhttps.protocols=TLSv1.2
 -Dmaven.wagon.http.retryHandler.count=3
 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+-Daether.checksumPolicy=fail


### PR DESCRIPTION
## Summary
- Removes `cache: 'maven'` from the `actions/setup-java` step in the `maven-goal` composite action, used by release workflows (`pre-post-release.yml`) as well as CI (`test.yml`).
- Adds `-Daether.checksumPolicy=fail` to `.mvn/maven.config` as defense in depth.
- Bumps `actions/setup-java` v4 -> v6 while touching this step.

## Why
Cache poisoning attack vector: a poisoned Maven dependency cache could be pulled into release artifacts. Same fix already applied and merged in the sibling repo apm-agent-java: elastic/apm-agent-java#4414.

## Test plan
- [ ] CI (`test.yml`) passes without the Maven cache
- [ ] `pre-post-release.yml` steps still function correctly without the cache